### PR TITLE
Fix $default-branch not being an actual feature we can use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,9 @@
 name: "CI"
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Part of migrating CI from GitLab to GitHub (#2).

Despite GitHub docs showing code for '$default-branch' (https://docs.github.com/en/actions/sharing-automations/creating-workflow-templates-for-your-organization), it is actually not a feature for Actions but rather just a static string replace that happens when you create a workflow using the web UI.