### PR TITLE
Fix CI Deploy stage not running if either of Typecheck/UTs were skipped

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,7 +202,7 @@ jobs:
     # pushes to the default branch (master). This job would probably also run on
     # forked repository's default branches, but they wouldn't have access to the
     # production secrets that's set in the GitHub repository settings UI.
-    if: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
     environment: production
     steps:
       - name: Rolling out to Production Kubernetes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
   typecheck-lint:
     name: Frontend Typecheck & Lint
     runs-on: ubuntu-latest
-    container: node:20-alpine
+    container: node:20
     needs: determine-changes
     # Only run for pull requests, since on pushes to the default branch, the
     # Docker image building step will run the frontend build anyway.


### PR DESCRIPTION
This happens due to actions/runner#2205.

If there is a chain of workflow jobs like: `A -> B -> C`, where if you want the chain to continue after A is skipped, you need to insert a `!failure() && !canceled()` as a condition for every subsequent job (i.e. both for B and C, not just for B).

This seems like a bug because intuitively you'd only set it for B, but the issue seems open with no actions taken, so we'll just follow the workaround of also setting the conditional for C too.

--

Also fixes caching not working for the frontend CI due to the use of an alpine image. Originally we were using the alpine one since the Tardis CI was slow and we wanted to opt for a lightweight image. But GitHub's runners are very speedy so I don't think there's any point in using alpine anymore.