### PR TITLE
Update repository link

### DIFF
--- a/frontend/public/static/config.js
+++ b/frontend/public/static/config.js
@@ -14,7 +14,7 @@ window.configOptions = {
       'childItems': [
         {
           'title': 'Repository',
-          'href': 'https://git.tardisproject.uk/betterinformatics/edinburgh-community-solutions'
+          'href': 'https://github.com/compsoc-edinburgh/betterinformatics-files'
         },
         {
           'title': 'Disclaimer',

--- a/frontend/src/pages/feedback-page.tsx
+++ b/frontend/src/pages/feedback-page.tsx
@@ -60,7 +60,7 @@ const FeedbackForm: React.FC<{}> = () => {
         <Anchor
           component="a"
           color="blue"
-          href="https://git.tardisproject.uk/betterinformatics/edinburgh-community-solutions"
+          href="https://github.com/compsoc-edinburgh/betterinformatics-files"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
There are two links which still point to the old repository on Tardis gitlab. This changes them to point to the new repository on GitHub.