### PR TITLE
Fix answers being hard to distinguish from each other

### DIFF
--- a/frontend/src/components/answer-section.tsx
+++ b/frontend/src/components/answer-section.tsx
@@ -235,7 +235,13 @@ const AnswerSectionComponent: React.FC<Props> = React.memo(
         )}
         <Container fluid pb="md" px="md">
           {!hidden && data && (
-            <div>
+            <Card
+              bg={computedColorScheme == "light" ? "gray.0" : "dark.7"}
+              shadow="md"
+              px="xs"
+              py="xs"
+              radius={0}
+            >
               {data.answers.map(answer => (
                 <AnswerComponent
                   key={answer.oid}
@@ -251,7 +257,7 @@ const AnswerSectionComponent: React.FC<Props> = React.memo(
                   onDelete={() => setHasDraft(false)}
                 />
               )}
-            </div>
+            </Card>
           )}
           <AnswerSectionButtonWrapper
             bg={computedColorScheme == "light" ? "gray.0" : "dark.7"}

--- a/frontend/src/components/answer.tsx
+++ b/frontend/src/components/answer.tsx
@@ -112,9 +112,10 @@ const AnswerComponent: React.FC<Props> = ({
     <>
       {modals}
       <Card
-        shadow="md"
+        mb="xs"
+        shadow="none"
+        withBorder
         id={hasId ? answer?.longId : undefined}
-        radius={0}
       >
         <Card.Section px="md" py="md" withBorder>
           <Flex justify="space-between" align="center">


### PR DESCRIPTION
Added back the small margin which was removed in b050388. It was originally removed since it looked 'off' that the answers were just floating, disconnected from each other. This PR adds a background Card component so the answers are all attached visually to the question.

![Image](https://i.imgur.com/NevYbhm.png)