### PR TITLE
Fix visual regression with padding after deleting an answer draft

### DIFF
--- a/frontend/src/components/answer-section.tsx
+++ b/frontend/src/components/answer-section.tsx
@@ -234,7 +234,12 @@ const AnswerSectionComponent: React.FC<Props> = React.memo(
             </NameCard>
           )}
         <Container fluid pb="md" px="md">
-          {!hidden && data && (
+          {/* Show answer background only if not hidden, and either answers
+          exist or there is a draft. Careful with the conditionals here because
+          if you start a draft on a collapsed question with no answers, and then
+          delete the draft, you'll end up with a 'expanded but no answers or
+          drafts' state. */}
+          {!hidden && data && (data.answers.length > 0 || hasDraft) && (
             <Card
               bg={computedColorScheme == "light" ? "gray.0" : "dark.7"}
               shadow="md"


### PR DESCRIPTION
#29 introduced a visual regression where there'd be unnatural padding if you delete an answer draft for a question with no existing answers. This PR fixes it.

(See the extra padding on the bottom question in the screenshot)
![Screenshot](https://f.monomorphic.party/u/gmrbKW.png)
