### PR TITLE
Fix not being able to set empty display name

### DIFF
--- a/frontend/src/components/user-displayname-settings.tsx
+++ b/frontend/src/components/user-displayname-settings.tsx
@@ -48,7 +48,6 @@ const UserDisplayNameSettings: React.FC<UserDisplayNameProps> = ({
             onChange={(e: any) =>
               setEditingDisplayUsername(e.currentTarget.value)
             }
-            required
             error={error ? error.toString() : ""}
             rightSection={
               loading ? (


### PR DESCRIPTION
Empty display names should be allowed to default back to the UUN, but currently the `required` prop makes it invalid to submit an empty display name. This PR fixes this.