### PR TITLE
Truncate long display names in frontend UI, limit to 32 chars in backend

### DIFF
--- a/backend/ediauth/views.py
+++ b/backend/ediauth/views.py
@@ -175,8 +175,13 @@ def update_name(request: HttpRequest):
     if display_username == "":
         # Use the UUN as the display name if the user didn't specify one
         display_username = request.user.username
-    if len(display_username) > 256:
-        return response.not_possible("Display name too long")
+
+    # Although the DB model allows for up to 256 characters, there was feedback
+    # that it is too much (and the frontend breaks). We've fixed the frontend
+    # to support arbitrary length so that's not a problem anymore, but we'll
+    # keep the limit to 32 characters since that feels more than enough.
+    if len(display_username) > 32:
+        return response.not_possible("Display name too long (max 32 characters)")
 
     request.user.profile.display_username = display_username.strip()
     request.user.profile.save()

--- a/frontend/src/components/answer.tsx
+++ b/frontend/src/components/answer.tsx
@@ -120,145 +120,145 @@ const AnswerComponent: React.FC<Props> = ({
       >
         <Card.Section px="md" py="md" withBorder>
           <Group gap={0}>
-              {!hasId && (
-                <Link
-                  to={
-                    answer ? `/exams/${answer.filename}#${answer.longId}` : ""
-                  }
-                >
-                  <Text mr={8} component="span">
-                    <IconLink style={{ height: "13px", width: "13px" }} />
-                  </Text>
-                </Link>
-              )}
-              <Anchor
-                component={Link}
-                to={`/user/${answer?.authorId ?? username}`}
-                className={displayNameClasses.shrinkableDisplayName}
+            {!hasId && (
+              <Link
+                to={
+                  answer ? `/exams/${answer.filename}#${answer.longId}` : ""
+                }
               >
-                <Text fw={700} component="span">
-                  {answer?.authorDisplayName ?? "(Draft)"}
+                <Text mr={8} component="span">
+                  <IconLink style={{ height: "13px", width: "13px" }} />
                 </Text>
-                <Text ml="0.3em" c="dimmed" component="span">
-                  @{answer?.authorId ?? username}
-                </Text>
-              </Anchor>
-              <Text c="dimmed" mx={6} component="span">
-                ·
+              </Link>
+            )}
+            <Anchor
+              component={Link}
+              to={`/user/${answer?.authorId ?? username}`}
+              className={displayNameClasses.shrinkableDisplayName}
+            >
+              <Text fw={700} component="span">
+                {answer?.authorDisplayName ?? "(Draft)"}
               </Text>
-              {answer && (
-                <TimeText time={answer.time} suffix="ago" />
+              <Text ml="0.3em" c="dimmed" component="span">
+                @{answer?.authorId ?? username}
+              </Text>
+            </Anchor>
+            <Text c="dimmed" mx={6} component="span">
+              ·
+            </Text>
+            {answer && (
+              <TimeText time={answer.time} suffix="ago" />
+            )}
+            {answer &&
+              differenceInSeconds(
+                new Date(answer.edittime),
+                new Date(answer.time),
+              ) > 1 && (
+                <>
+                  <Text color="dimmed" mx={6} component="span">
+                    ·
+                  </Text>
+                  <TimeText time={answer.edittime} prefix="edited" suffix="ago" />
+                </>
               )}
+            <AnswerToolbar ml="auto">
               {answer &&
-                differenceInSeconds(
-                  new Date(answer.edittime),
-                  new Date(answer.time),
-                ) > 1 && (
-                  <>
-                    <Text color="dimmed" mx={6} component="span">
-                      ·
-                    </Text>
-                    <TimeText time={answer.edittime} prefix="edited" suffix="ago" />
-                  </>
-                )}
-              <AnswerToolbar ml="auto">
-                {answer &&
-                  (answer.expertvotes > 0 ||
-                    setExpertVoteLoading ||
-                    isExpert) && (
-                    <Paper shadow="xs">
-                      <Button.Group>
+                (answer.expertvotes > 0 ||
+                  setExpertVoteLoading ||
+                  isExpert) && (
+                  <Paper shadow="xs">
+                    <Button.Group>
+                      <TooltipButton
+                        px={12}
+                        tooltip="This answer is endorsed by an expert"
+                        variant="filled"
+                        color="yellow"
+                      >
+                        <IconStarFilled />
+                      </TooltipButton>
+                      <TooltipButton
+                        miw={30}
+                        tooltip={`${answer.expertvotes} experts endorse this answer.`}
+                        loading={setExpertVoteLoading}
+                      >
+                        {answer.expertvotes}
+                      </TooltipButton>
+                      {isExpert && (
                         <TooltipButton
-                          px={12}
-                          tooltip="This answer is endorsed by an expert"
-                          variant="filled"
-                          color="yellow"
-                        >
-                          <IconStarFilled />
-                        </TooltipButton>
-                        <TooltipButton
-                          miw={30}
-                          tooltip={`${answer.expertvotes} experts endorse this answer.`}
-                          loading={setExpertVoteLoading}
-                        >
-                          {answer.expertvotes}
-                        </TooltipButton>
-                        {isExpert && (
-                          <TooltipButton
-                            size="sm"
-                            px={8}
-                            tooltip={
-                              answer.isExpertVoted
-                                ? "Remove expert vote"
-                                : "Add expert vote"
-                            }
-                            style={{ borderLeftWidth: 0 }}
-                            onClick={() =>
-                              setExpertVote(answer.oid, !answer.isExpertVoted)
-                            }
-                          >
-                            {answer.isExpertVoted ? (
-                              <IconChevronDown />
-                            ) : (
-                              <IconChevronUp />
-                            )}
-                          </TooltipButton>
-                        )}
-                      </Button.Group>
-                    </Paper>
-                  )}
-                {answer &&
-                  (answer.isFlagged ||
-                    (answer.flagged > 0 && isAdmin) ||
-                    flaggedLoading) && (
-                    <Paper shadow="xs">
-                      <Button.Group>
-                        <TooltipButton
-                          tooltip="Flagged as Inappropriate"
-                          color="red"
-                          px={12}
-                          variant="filled"
-                        >
-                          <IconFlag />
-                        </TooltipButton>
-                        <TooltipButton
-                          color="red"
-                          miw={30}
-                          tooltip={`${answer.flagged} users consider this answer inappropriate.`}
-                        >
-                          {answer.flagged}
-                        </TooltipButton>
-                        <TooltipButton
+                          size="sm"
                           px={8}
                           tooltip={
-                            answer.isFlagged
-                              ? "Remove inappropriate flag"
-                              : "Add inappropriate flag"
+                            answer.isExpertVoted
+                              ? "Remove expert vote"
+                              : "Add expert vote"
                           }
-                          size="sm"
-                          loading={flaggedLoading}
                           style={{ borderLeftWidth: 0 }}
                           onClick={() =>
-                            setFlagged(answer.oid, !answer.isFlagged)
+                            setExpertVote(answer.oid, !answer.isExpertVoted)
                           }
                         >
-                          {answer.isFlagged ? <IconX /> : <IconChevronUp />}
+                          {answer.isExpertVoted ? (
+                            <IconChevronDown />
+                          ) : (
+                            <IconChevronUp />
+                          )}
                         </TooltipButton>
-                      </Button.Group>
-                    </Paper>
-                  )}
-                {answer && onSectionChanged && (
-                  <Score
-                    oid={answer.oid}
-                    upvotes={answer.upvotes}
-                    expertUpvotes={answer.expertvotes}
-                    userVote={
-                      answer.isUpvoted ? 1 : answer.isDownvoted ? -1 : 0
-                    }
-                    onSectionChanged={onSectionChanged}
-                  />
+                      )}
+                    </Button.Group>
+                  </Paper>
                 )}
-              </AnswerToolbar>
+              {answer &&
+                (answer.isFlagged ||
+                  (answer.flagged > 0 && isAdmin) ||
+                  flaggedLoading) && (
+                  <Paper shadow="xs">
+                    <Button.Group>
+                      <TooltipButton
+                        tooltip="Flagged as Inappropriate"
+                        color="red"
+                        px={12}
+                        variant="filled"
+                      >
+                        <IconFlag />
+                      </TooltipButton>
+                      <TooltipButton
+                        color="red"
+                        miw={30}
+                        tooltip={`${answer.flagged} users consider this answer inappropriate.`}
+                      >
+                        {answer.flagged}
+                      </TooltipButton>
+                      <TooltipButton
+                        px={8}
+                        tooltip={
+                          answer.isFlagged
+                            ? "Remove inappropriate flag"
+                            : "Add inappropriate flag"
+                        }
+                        size="sm"
+                        loading={flaggedLoading}
+                        style={{ borderLeftWidth: 0 }}
+                        onClick={() =>
+                          setFlagged(answer.oid, !answer.isFlagged)
+                        }
+                      >
+                        {answer.isFlagged ? <IconX /> : <IconChevronUp />}
+                      </TooltipButton>
+                    </Button.Group>
+                  </Paper>
+                )}
+              {answer && onSectionChanged && (
+                <Score
+                  oid={answer.oid}
+                  upvotes={answer.upvotes}
+                  expertUpvotes={answer.expertvotes}
+                  userVote={
+                    answer.isUpvoted ? 1 : answer.isDownvoted ? -1 : 0
+                  }
+                  onSectionChanged={onSectionChanged}
+                />
+              )}
+            </AnswerToolbar>
           </Group>
         </Card.Section>
         {editing || answer === undefined ? (

--- a/frontend/src/components/answer.tsx
+++ b/frontend/src/components/answer.tsx
@@ -48,6 +48,7 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import classes from "./answer.module.css";
+import displayNameClasses from "../utils/display-name.module.css";
 import { useDisclosure } from "@mantine/hooks";
 import TimeText from "./time-text";
 
@@ -118,8 +119,7 @@ const AnswerComponent: React.FC<Props> = ({
         id={hasId ? answer?.longId : undefined}
       >
         <Card.Section px="md" py="md" withBorder>
-          <Flex justify="space-between" align="center">
-            <div>
+          <Group gap={0}>
               {!hasId && (
                 <Link
                   to={
@@ -134,6 +134,7 @@ const AnswerComponent: React.FC<Props> = ({
               <Anchor
                 component={Link}
                 to={`/user/${answer?.authorId ?? username}`}
+                className={displayNameClasses.shrinkableDisplayName}
               >
                 <Text fw={700} component="span">
                   {answer?.authorDisplayName ?? "(Draft)"}
@@ -160,9 +161,7 @@ const AnswerComponent: React.FC<Props> = ({
                     <TimeText time={answer.edittime} prefix="edited" suffix="ago" />
                   </>
                 )}
-            </div>
-            <Flex>
-              <AnswerToolbar>
+              <AnswerToolbar ml="auto">
                 {answer &&
                   (answer.expertvotes > 0 ||
                     setExpertVoteLoading ||
@@ -260,8 +259,7 @@ const AnswerComponent: React.FC<Props> = ({
                   />
                 )}
               </AnswerToolbar>
-            </Flex>
-          </Flex>
+          </Group>
         </Card.Section>
         {editing || answer === undefined ? (
           <Card.Section>

--- a/frontend/src/components/comment-single.tsx
+++ b/frontend/src/components/comment-single.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Box, Breadcrumbs, Card, Divider, Text } from "@mantine/core";
+import { Anchor, Breadcrumbs, Card, Divider, Group, Text } from "@mantine/core";
 import { differenceInSeconds } from "date-fns";
 import React from "react";
 import { Link } from "react-router-dom";
@@ -7,6 +7,7 @@ import MarkdownText from "./markdown-text";
 import TimeText from "./time-text";
 import { IconChevronRight } from "@tabler/icons-react";
 import classes from "./comment-single.module.css";
+import displayNameClasses from "../utils/display-name.module.css";
 
 interface Props {
   comment: SingleComment;
@@ -49,8 +50,12 @@ const SingleCommentComponent: React.FC<Props> = ({ comment }) => {
             Comment
           </Anchor>
         </Breadcrumbs>
-        <Box my="xs" px="md">
-          <Anchor component={Link} to={`/user/${comment.authorId}`}>
+        <Group my="xs" px="md" gap={0}>
+          <Anchor
+            component={Link}
+            to={`/user/${comment.authorId}`}
+            className={displayNameClasses.shrinkableDisplayName}
+          >
             <Text fw={700} component="span">
               {comment.authorDisplayName}
             </Text>
@@ -76,7 +81,7 @@ const SingleCommentComponent: React.FC<Props> = ({ comment }) => {
                 <TimeText time={comment.edittime} prefix="edited" suffix="ago" />
               </>
             )}
-        </Box>
+        </Group>
         <Divider />
       </Card.Section>
       <MarkdownText value={comment.text} />

--- a/frontend/src/components/comment.tsx
+++ b/frontend/src/components/comment.tsx
@@ -22,6 +22,7 @@ import {
 import IconButton from "./icon-button";
 import { useDisclosure } from "@mantine/hooks";
 import TimeText from "./time-text";
+import displayNameClasses from "../utils/display-name.module.css";
 
 interface Props {
   answer: Answer;
@@ -87,11 +88,11 @@ const CommentComponent: React.FC<Props> = ({
       style={{ marginBottom: "-1px" }}
     >
       {modals}
-      <Flex justify="space-between">
-        <div>
+      <Group gap={0}>
           <Anchor
             component={Link}
             to={`/user/${comment?.authorId ?? username}`}
+            className={displayNameClasses.shrinkableDisplayName}
           >
             <Text fw={700} component="span">
               {comment?.authorDisplayName ?? "(Draft)"}
@@ -118,9 +119,8 @@ const CommentComponent: React.FC<Props> = ({
                 <TimeText time={comment.edittime} prefix="edited" suffix="ago" />
               </>
             )}
-        </div>
         {comment && !editing && comment.canEdit && (
-          <Button.Group>
+          <Button.Group ml="auto">
             <IconButton
               tooltip="Edit comment"
               color="gray"
@@ -149,13 +149,14 @@ const CommentComponent: React.FC<Props> = ({
         )}
         {comment && !editing && !comment.canEdit && (
           <IconButton
+            ml="auto"
             tooltip="Toggle Source Code Mode"
             color="gray"
             onClick={toggleViewSource}
             icon={<IconCode />}
           />
         )}
-      </Flex>
+      </Group>
 
       {comment === undefined || editing ? (
         <>

--- a/frontend/src/components/comment.tsx
+++ b/frontend/src/components/comment.tsx
@@ -89,36 +89,36 @@ const CommentComponent: React.FC<Props> = ({
     >
       {modals}
       <Group gap={0}>
-          <Anchor
-            component={Link}
-            to={`/user/${comment?.authorId ?? username}`}
-            className={displayNameClasses.shrinkableDisplayName}
-          >
-            <Text fw={700} component="span">
-              {comment?.authorDisplayName ?? "(Draft)"}
-            </Text>
-            <Text ml="0.25em" color="dimmed" component="span">
-              @{comment?.authorId ?? username}
-            </Text>
-          </Anchor>
-          <Text component="span" mx={6} color="dimmed">
-            ·
+        <Anchor
+          component={Link}
+          to={`/user/${comment?.authorId ?? username}`}
+          className={displayNameClasses.shrinkableDisplayName}
+        >
+          <Text fw={700} component="span">
+            {comment?.authorDisplayName ?? "(Draft)"}
           </Text>
-          {comment && (
-            <TimeText time={comment.time} suffix="ago" />
+          <Text ml="0.25em" color="dimmed" component="span">
+            @{comment?.authorId ?? username}
+          </Text>
+        </Anchor>
+        <Text component="span" mx={6} color="dimmed">
+          ·
+        </Text>
+        {comment && (
+          <TimeText time={comment.time} suffix="ago" />
+        )}
+        {comment &&
+          differenceInSeconds(
+            new Date(comment.edittime),
+            new Date(comment.time),
+          ) > 1 && (
+            <>
+              <Text component="span" mx={6} color="dimmed">
+                ·
+              </Text>
+              <TimeText time={comment.edittime} prefix="edited" suffix="ago" />
+            </>
           )}
-          {comment &&
-            differenceInSeconds(
-              new Date(comment.edittime),
-              new Date(comment.time),
-            ) > 1 && (
-              <>
-                <Text component="span" mx={6} color="dimmed">
-                  ·
-                </Text>
-                <TimeText time={comment.edittime} prefix="edited" suffix="ago" />
-              </>
-            )}
         {comment && !editing && comment.canEdit && (
           <Button.Group ml="auto">
             <IconButton

--- a/frontend/src/components/document-comment.tsx
+++ b/frontend/src/components/document-comment.tsx
@@ -25,6 +25,7 @@ import SmallButton from "./small-button";
 import TooltipButton from "./TooltipButton";
 import { IconEdit, IconTrash } from "@tabler/icons-react";
 import TimeText from "./time-text";
+import displayNameClasses from "../utils/display-name.module.css";
 
 interface Props {
   documentSlug: string;
@@ -85,8 +86,11 @@ const DocumentCommentComponent = ({ documentSlug, comment, mutate }: Props) => {
       <Card withBorder shadow="md" my="sm">
         <Card.Section mb="sm">
           <Flex py="sm" px="md" justify="space-between" align="center">
-            <Flex align="center">
-              <Anchor component={Link} to={`/user/${comment.authorId}`}>
+              <Anchor
+                component={Link}
+                to={`/user/${comment.authorId}`}
+                className={displayNameClasses.shrinkableDisplayName}
+              >
                 <Text fw={700} component="span">
                   {comment.authorDisplayName}
                 </Text>
@@ -112,9 +116,8 @@ const DocumentCommentComponent = ({ documentSlug, comment, mutate }: Props) => {
                     <TimeText time={comment.edittime} prefix="edited" suffix="ago" />
                   </>
                 )}
-            </Flex>
             {(comment.canEdit || isAdmin) && (
-              <Button.Group>
+              <Button.Group ml="auto">
                 <SmallButton
                   tooltip="Delete comment"
                   size="xs"

--- a/frontend/src/components/document-comment.tsx
+++ b/frontend/src/components/document-comment.tsx
@@ -86,36 +86,36 @@ const DocumentCommentComponent = ({ documentSlug, comment, mutate }: Props) => {
       <Card withBorder shadow="md" my="sm">
         <Card.Section mb="sm">
           <Flex py="sm" px="md" justify="space-between" align="center">
-              <Anchor
-                component={Link}
-                to={`/user/${comment.authorId}`}
-                className={displayNameClasses.shrinkableDisplayName}
-              >
-                <Text fw={700} component="span">
-                  {comment.authorDisplayName}
-                </Text>
-                <Text ml="0.25em" color="dimmed" component="span">
-                  @{comment.authorId}
-                </Text>
-              </Anchor>
-              <Text component="span" mx={6} color="dimmed">
-                ·
+            <Anchor
+              component={Link}
+              to={`/user/${comment.authorId}`}
+              className={displayNameClasses.shrinkableDisplayName}
+            >
+              <Text fw={700} component="span">
+                {comment.authorDisplayName}
               </Text>
-              {comment && (
-                <TimeText time={comment.time} suffix="ago" />
+              <Text ml="0.25em" color="dimmed" component="span">
+                @{comment.authorId}
+              </Text>
+            </Anchor>
+            <Text component="span" mx={6} color="dimmed">
+              ·
+            </Text>
+            {comment && (
+              <TimeText time={comment.time} suffix="ago" />
+            )}
+            {comment &&
+              differenceInSeconds(
+                new Date(comment.edittime),
+                new Date(comment.time),
+              ) > 1 && (
+                <>
+                  <Text component="span" color="dimmed" mx={6}>
+                    ·
+                  </Text>
+                  <TimeText time={comment.edittime} prefix="edited" suffix="ago" />
+                </>
               )}
-              {comment &&
-                differenceInSeconds(
-                  new Date(comment.edittime),
-                  new Date(comment.time),
-                ) > 1 && (
-                  <>
-                    <Text component="span" color="dimmed" mx={6}>
-                      ·
-                    </Text>
-                    <TimeText time={comment.edittime} prefix="edited" suffix="ago" />
-                  </>
-                )}
             {(comment.canEdit || isAdmin) && (
               <Button.Group ml="auto">
                 <SmallButton

--- a/frontend/src/components/feedback-entry.tsx
+++ b/frontend/src/components/feedback-entry.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { fetchPost } from "../api/fetch-utils";
 import GlobalConsts from "../globalconsts";
 import { FeedbackEntry } from "../interfaces";
+import displayNameClasses from "../utils/display-name.module.css";
 
 const setFlag = async (oid: string, flag: "done" | "read", value: boolean) => {
   await fetchPost(`/api/feedback/flags/${oid}/`, {
@@ -33,7 +34,7 @@ const FeedbackEntryComponent: React.FC<Props> = ({ entry, entryChanged }) => {
     <Card my="xs" withBorder shadow="md">
       <Card.Section withBorder inheritPadding>
         <Group py="md" justify="space-between">
-          <Title order={4}>
+          <Title order={4} className={displayNameClasses.shrinkableDisplayName}>
             {entry.authorDisplayName} •{" "}
             {moment(entry.time, GlobalConsts.momentParseString).format(
               GlobalConsts.momentFormatString,

--- a/frontend/src/components/search-results.tsx
+++ b/frontend/src/components/search-results.tsx
@@ -17,6 +17,7 @@ import MarkdownText from "../components/markdown-text";
 import { HighlightedMatch, SearchResponse } from "../interfaces";
 import { IconChevronRight } from "@tabler/icons-react";
 import classes from "./search-results.module.css";
+import displayNameClasses from "../utils/display-name.module.css";
 
 const HighlightedContent: React.FC<{
   content: HighlightedMatch;
@@ -151,8 +152,14 @@ const SearchResults: React.FC<Props> = React.memo(({ data }) => {
                   <Anchor
                     component={Link}
                     to={`/exams/${result.filename}/#${result.long_id}`}
+                    // miw required for ellipsis in nested child to work
+                    miw={0}
                   >
-                    <Title py="xs" order={4}>
+                    <Title
+                      py="xs"
+                      order={4}
+                      className={displayNameClasses.shrinkableDisplayName}
+                    >
                       {result.author_displayname}
                     </Title>
                   </Anchor>
@@ -198,8 +205,13 @@ const SearchResults: React.FC<Props> = React.memo(({ data }) => {
                   <Anchor
                     component={Link}
                     to={`/exams/${result.filename}/#${result.long_id}`}
+                    miw={0}
                   >
-                    <Title py="xs" order={4}>
+                    <Title
+                      py="xs"
+                      order={4}
+                      className={displayNameClasses.shrinkableDisplayName}
+                    >
                       {result.author_displayname}
                     </Title>
                   </Anchor>

--- a/frontend/src/components/user-displayname-settings.tsx
+++ b/frontend/src/components/user-displayname-settings.tsx
@@ -35,19 +35,22 @@ const UserDisplayNameSettings: React.FC<UserDisplayNameProps> = ({
       <h3>Display Username</h3>
       <Text mb="xs">
         You can choose to set a name that is displayed next to your UUN in
-        comments and answers you submit. This does not hide your UUN.
+        comments and answers you submit. This is purely cosmetic, and does not
+        hide your UUN from other users.
       </Text>
       <form onSubmit={handleSubmitDisplayName}>
         <SimpleGrid
           cols={{ xl: 4, sm: 1, md: 2 }}
         >
           <TextInput
-            label="Display Name"
+            label="Display Username (max 32 characters)"
             placeholder="Leave empty to use your UUN"
             value={editingDisplayUsername}
             onChange={(e: any) =>
               setEditingDisplayUsername(e.currentTarget.value)
             }
+            // Backend will return error if name is too long
+            maxLength={32}
             error={error ? error.toString() : ""}
             rightSection={
               loading ? (

--- a/frontend/src/components/user-score-card.tsx
+++ b/frontend/src/components/user-score-card.tsx
@@ -22,6 +22,7 @@ import {
   IconPencil,
   IconProps,
 } from "@tabler/icons-react";
+import displayNameClasses from "../utils/display-name.module.css";
 
 interface UserScoreCardProps {
   username?: string;
@@ -69,7 +70,7 @@ const UserScoreCard: React.FC<UserScoreCardProps> = ({
   return (
     <>
       <Group justify="space-between" mb="sm">
-        <Title order={1} my="md">
+        <Title order={1} my="md" className={displayNameClasses.shrinkableDisplayName}>
           @{username}{" "}
           {userInfo &&
             userInfo.displayName !== username &&

--- a/frontend/src/pages/document-page.tsx
+++ b/frontend/src/pages/document-page.tsx
@@ -133,68 +133,68 @@ const DocumentPage: React.FC<Props> = () => {
               </Group>
             </Flex>
             <Group gap={0}>
-            {data && !data.anonymised && (
-              <Anchor
-                component={Link}
-                to={`/user/${data.author}`}
-                underline="never"
-                className={displayNameClasses.shrinkableDisplayName}
-              >
-                {data.author_displayname !== data.author && (
-                  <>
+              {data && !data.anonymised && (
+                <Anchor
+                  component={Link}
+                  to={`/user/${data.author}`}
+                  underline="never"
+                  className={displayNameClasses.shrinkableDisplayName}
+                >
+                  {data.author_displayname !== data.author && (
+                    <>
+                      <Text fw={700} component="span">
+                        {data.author_displayname}
+                      </Text>
+                      <Text ml="0.3em" c="dimmed" component="span">
+                        @{data.author}
+                      </Text>
+                    </>
+                  )}
+                  {data.author_displayname === data.author && (
                     <Text fw={700} component="span">
-                      {data.author_displayname}
-                    </Text>
-                    <Text ml="0.3em" c="dimmed" component="span">
                       @{data.author}
                     </Text>
-                  </>
-                )}
-                {data.author_displayname === data.author && (
-                  <Text fw={700} component="span">
-                    @{data.author}
-                  </Text>
-                )}
-              </Anchor>
-            )}
-            {data && data.anonymised && (
-              <Text fw={700} component="span">
-                Anonymous
-              </Text>
-            )}
-            {data && data.anonymised && (data.can_edit || data.can_delete) && (
-              <Anchor
-                component={Link}
-                to={`/user/${data.author}`}
-                underline="never"
-                className={displayNameClasses.shrinkableDisplayName}
-              >
-                <Text ml="0.3em" c="dimmed" component="span">
-                  (
-                  {data.author_displayname !== data.author &&
-                    `${data.author_displayname} `}
-                  @{data.author})
+                  )}
+                </Anchor>
+              )}
+              {data && data.anonymised && (
+                <Text fw={700} component="span">
+                  Anonymous
                 </Text>
-              </Anchor>
-            )}
-            {differenceInSeconds(new Date(data.edittime), new Date(data.time)) >
-              1 && (
-              <>
-                <Text c="dimmed" mx={6} component="span">
-                  ·
-                </Text>
-                <Tooltip
-                  withArrow
-                  withinPortal
-                  label={`Created ${formatDistanceToNow(new Date(data.time))} ago`}
-                  disabled={data.time === null}
+              )}
+              {data && data.anonymised && (data.can_edit || data.can_delete) && (
+                <Anchor
+                  component={Link}
+                  to={`/user/${data.author}`}
+                  underline="never"
+                  className={displayNameClasses.shrinkableDisplayName}
                 >
-                  <Text c="dimmed" component="span">
-                    updated {formatDistanceToNow(new Date(data.edittime))} ago
+                  <Text ml="0.3em" c="dimmed" component="span">
+                    (
+                    {data.author_displayname !== data.author &&
+                      `${data.author_displayname} `}
+                    @{data.author})
                   </Text>
-                </Tooltip>
-              </>
-            )}
+                </Anchor>
+              )}
+              {differenceInSeconds(new Date(data.edittime), new Date(data.time)) >
+                1 && (
+                <>
+                  <Text c="dimmed" mx={6} component="span">
+                    ·
+                  </Text>
+                  <Tooltip
+                    withArrow
+                    withinPortal
+                    label={`Created ${formatDistanceToNow(new Date(data.time))} ago`}
+                    disabled={data.time === null}
+                  >
+                    <Text c="dimmed" component="span">
+                      updated {formatDistanceToNow(new Date(data.edittime))} ago
+                    </Text>
+                  </Tooltip>
+                </>
+              )}
             </Group>
           </Box>
         )}

--- a/frontend/src/pages/document-page.tsx
+++ b/frontend/src/pages/document-page.tsx
@@ -40,6 +40,7 @@ import {
   IconSettings,
 } from "@tabler/icons-react";
 import { useDisclosure } from "@mantine/hooks";
+import displayNameClasses from "../utils/display-name.module.css";
 
 const isPdf = (file: DocumentFile) => file.mime_type === "application/pdf";
 const isMarkdown = (file: DocumentFile) =>
@@ -131,11 +132,13 @@ const DocumentPage: React.FC<Props> = () => {
                 <LikeButton document={data} mutate={mutate} />
               </Group>
             </Flex>
+            <Group gap={0}>
             {data && !data.anonymised && (
               <Anchor
                 component={Link}
                 to={`/user/${data.author}`}
                 underline="never"
+                className={displayNameClasses.shrinkableDisplayName}
               >
                 {data.author_displayname !== data.author && (
                   <>
@@ -164,6 +167,7 @@ const DocumentPage: React.FC<Props> = () => {
                 component={Link}
                 to={`/user/${data.author}`}
                 underline="never"
+                className={displayNameClasses.shrinkableDisplayName}
               >
                 <Text ml="0.3em" c="dimmed" component="span">
                   (
@@ -191,6 +195,7 @@ const DocumentPage: React.FC<Props> = () => {
                 </Tooltip>
               </>
             )}
+            </Group>
           </Box>
         )}
         {error && <Alert color="red">{error.toString()}</Alert>}

--- a/frontend/src/utils/display-name.module.css
+++ b/frontend/src/utils/display-name.module.css
@@ -1,0 +1,15 @@
+/**
+  * Class for the display name element within a horizontal <Group> component.
+  * This is used to ensure that the display name is always on one line and
+  * becomes ellipsized if it is too long. It also grows to fill available space
+  * up to a maximum width determined by the content of the display name.
+  */
+.shrinkableDisplayName {
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  flex-grow: 1;
+  flex-basis: 4em;
+  min-width: 4em;
+  max-width: fit-content;
+}


### PR DESCRIPTION
(The diff is cleaner if you choose not to show whitespace diffs -- the second commit is entirely indentation changes)
Before:

![Image](https://i.imgur.com/NcnP3Bv.png)

After:

![Image](https://i.imgur.com/qWGmB5z.png)

Applies to all places I could find which uses the author display name:
- User profile pages
- Answers
- Comments
- Search results
- Feedback entries
- Document authors
- Document comments
Resolves #34 .