### PR TITLE
Fix `mc config` no longer being available in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         run: |
           curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o mc
           chmod +x ./mc
-          ./mc config host add myminio http://minio:9000 minio minio123
+          ./mc alias set myminio http://minio:9000 minio minio123
           ./mc mb myminio/community-solutions
 
       - name: Install poppler


### PR DESCRIPTION
The CI for setting up a Minio database has started to fail recently due to `mc config` being removed (https://github.com/minio/mc/issues/5206).

This PR fixes it by using the replacement `mc alias` command.

The Docker Compose file for launching a local development environment is unaffected since it has a pinned Minio and Minio Client version from 2023.