### PR TITLE
Add self-hosted analytics tag to frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,11 @@
       %VITE_SERVER_DATA%
     </script>
     <script src="/static/config.js"></script>
+    <script
+      src="https://analytics.betterinformatics.com/api/script.js"
+      data-site-id="2"
+      defer
+    ></script>
     <title>File Collection</title>
     <meta name="description" content="BI File Collection is a platform for students to collaborate on past exam paper answers and share course notes/cheatsheets/Anki decks/etc.">
     <meta property="og:title" content="BetterInformatics File Collection">


### PR DESCRIPTION
Part of #52. Analytics should give us concrete numbers to base our decisions. A similar script is added to OG Better Informatics.

Data is collected in a self-hosted Rybbit instance on Tardis servers, hosted within Edinburgh. 

(We're going to have to update the privacy policy to include this)