### PR TITLE
Fix CSP_CONNECT_SRC not including analytics endpoint

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -223,6 +223,8 @@ CSP_CONNECT_SRC = (
     # the Markdown renderer should prevent it from being executed)
     "https://raw.githubusercontent.com/compsoc-edinburgh/betterinformatics/master/_sections/",
     "https://betterinformatics.com/courses.json",
+    # Allow self hosted tracking
+    "https://analytics.betterinformatics.com/api/",
 )
 CSP_IMG_SRC = (
     "'self'",


### PR DESCRIPTION
Bah! *Still* forgot to add CSP rules, this time for `fetch()` requests for analytics.