### PR TITLE
Pin Postgres version in local development to 16-bookworm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     entrypoint: >
       /bin/sh -c " /usr/bin/mc config host add myminio http://minio:9000 minio minio123; /usr/bin/mc mb myminio/community-solutions; "
   postgres:
-    image: postgres:16
+    image: postgres:16-bookworm
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres


### PR DESCRIPTION
The `16` tag has moved to trixie. However, production runs on 16-bookworm. To prevent unexpected collation version mismatch related issues, we update the local development image tags for Postgres to explicitly use the bookworm image as well.