### PR TITLE
Force use of black filled color for 'Add Answer' buttons

### DIFF
--- a/frontend/src/components/answer-section.tsx
+++ b/frontend/src/components/answer-section.tsx
@@ -80,7 +80,11 @@ const AddButton: React.FC<AddButtonProps> = ({
     return (
       <Menu opened={isOpen} withinPortal onChange={toggle}>
         <Menu.Target>
-          <ShimmerButton rightSection={<IconChevronDown />}>
+          <ShimmerButton
+            rightSection={<IconChevronDown />}
+            variant="filled"
+            color="black"
+          >
             Add Answer
           </ShimmerButton>
         </Menu.Target>
@@ -109,6 +113,8 @@ const AddButton: React.FC<AddButtonProps> = ({
       <Group grow>
         {allowAnswer && (
           <ShimmerButton
+            variant="filled"
+            color="black"
             size="sm"
             onClick={onAnswer}
             disabled={draftType === AnswerKind.Personal}
@@ -118,6 +124,8 @@ const AddButton: React.FC<AddButtonProps> = ({
         )}
         {allowOfficialAnswer && (
           <ShimmerButton
+            variant="filled"
+            color="black"
             size="sm"
             onClick={onOfficialAnswer}
             disabled={draftType === AnswerKind.Official}


### PR DESCRIPTION
After #86, the color of 'Add Answer' buttons changed from black to the primary color (brown).

This was not intended, since now there is visual confusion between the expand/collapse buttons and that button. This PR forces the use of black (both on light and dark mode) for the 'Add Answer' buttons.