### PR TITLE
Remove changelog modal, put latest version in footer

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -51,7 +51,6 @@ import {
 } from "./components/Navbar/constants";
 import { useDisclosure } from "@mantine/hooks";
 import AnnouncementHeader from "./components/Navbar/AnnouncementHeader";
-import ChangelogNotifier from "./components/ChangelogNotifier";
 import FlaggedContent from "./pages/flagged-content";
 import { FaroRoutes } from "@grafana/faro-react";
 import serverData from "./utils/server-data";
@@ -312,7 +311,6 @@ const App: React.FC = () => {
                   title={"File Collection"}
                 />
                 <AnnouncementHeader />
-                <ChangelogNotifier />
                 <Box component="main" mt="2em">
                   <TelemetryRoutes>
                     <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/components/footer.tsx
+++ b/frontend/src/components/footer.tsx
@@ -14,6 +14,7 @@ import {
 import { useLocalStorageState } from "ahooks";
 import { IconHeartFilled } from "@tabler/icons-react";
 import { NavItem, globalNav, translate } from "./Navbar/GlobalNav";
+import { latestVersion } from "../utils/changelog";
 
 interface FooterProps {
   logo: string;
@@ -105,6 +106,14 @@ const Footer: React.FC<FooterProps> = ({
               >
                 CompSoc
               </Anchor>
+              <br />
+            </Text>
+            <Text size="xs" c="gray.5" mt="md">
+              Version {latestVersion} (
+              <Anchor href="/changelog" c="blue.4">
+                see changelog
+              </Anchor>
+              )
             </Text>
           </Flex>
           <Group align="start">


### PR DESCRIPTION
The changelog modal feels a little too in-your-face. This PR removes it, and replaces it with a new footer component that references the latest version and a link to the changelog. 

Unfortunately this would probably limit the visibility of changes for users (thus limiting contributors long-term), so maybe this change might be reversed.