### PR TITLE
Show last edited time on documents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to this project are documented in this file.
 
+## v2026.04.edi1
+
+- Fixed visual regressions from previous version
+- Added last edit time of documents in the course page (by user request)
+
 ## v2026.04.edi0 (Based on upstream v2026.04.p0)
 
 - Merged all changes from upstream up to v2026.04.p0. See below for changelog  (#86).

--- a/frontend/src/components/document-card.tsx
+++ b/frontend/src/components/document-card.tsx
@@ -5,6 +5,7 @@ import { Anchor, Badge, Card, Flex, Group, Text } from "@mantine/core";
 import { IconHeart, IconHeartFilled } from "@tabler/icons-react";
 import clsx from "clsx";
 import classes from "../utils/focus-outline.module.css";
+import { formatDistanceToNow } from "date-fns";
 
 interface DocumentCardProps {
   document: Document;
@@ -15,6 +16,7 @@ const DocumentCard: React.FC<DocumentCardProps> = ({
   document,
   showCategory,
 }) => {
+  const lastUpdated = document.edittime ?? document.time;
   return (
     <Card
       withBorder
@@ -29,7 +31,13 @@ const DocumentCard: React.FC<DocumentCardProps> = ({
       <Text size="lg" lineClamp={3}>
         {document.display_name}
       </Text>
-      <Group justify="space-between" mt="sm">
+
+      {lastUpdated && (
+        <Text c="dimmed" component="span" size="xs">
+          Last updated {formatDistanceToNow(new Date(lastUpdated))} ago
+        </Text>
+      )}
+      <Group justify="space-between" mt="xs">
         {document.anonymised ? (
           <Text c="dimmed">Anonymous</Text>
         ) : (

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -380,8 +380,8 @@ export interface Document {
   files: DocumentFile[];
   liked: boolean;
   like_count: number;
-  time: string; // ISO 8601, creation time
-  edittime: string; // ISO 8601, last edit time
+  time: string | null; // ISO 8601, creation time
+  edittime: string | null; // ISO 8601, last edit time
 
   can_edit: boolean;
   can_delete: boolean;

--- a/frontend/src/pages/document-page.tsx
+++ b/frontend/src/pages/document-page.tsx
@@ -11,7 +11,6 @@ import {
   Text,
   Tabs,
   Box,
-  Tooltip,
 } from "@mantine/core";
 import React, { useEffect, useState } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
@@ -30,7 +29,7 @@ import DocumentSettings from "../components/document-settings";
 import { useDocumentDownload } from "../hooks/useDocumentDownload";
 import { Document, DocumentFile } from "../interfaces";
 import MarkdownText from "../components/markdown-text";
-import { differenceInSeconds, formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 import {
   IconChevronRight,
   IconDownload,
@@ -135,6 +134,8 @@ const DocumentPage: React.FC<Props> = () => {
     return `${file.display_name}.${ext}`;
   }
 
+  const lastEdited = data?.edittime ?? data?.time;
+
   return (
     <>
       <Container size="xl">
@@ -221,24 +222,14 @@ const DocumentPage: React.FC<Props> = () => {
                     </Text>
                   </Anchor>
                 )}
-              {differenceInSeconds(
-                new Date(data.edittime),
-                new Date(data.time),
-              ) > 1 && (
+              {lastEdited && (
                 <>
                   <Text c="dimmed" mx={6} component="span">
                     ·
                   </Text>
-                  <Tooltip
-                    withArrow
-                    withinPortal
-                    label={`Created ${formatDistanceToNow(new Date(data.time))} ago`}
-                    disabled={data.time === null}
-                  >
-                    <Text c="dimmed" component="span">
-                      updated {formatDistanceToNow(new Date(data.edittime))} ago
-                    </Text>
-                  </Tooltip>
+                  <Text c="dimmed" component="span">
+                    Last updated {formatDistanceToNow(new Date(lastEdited))} ago
+                  </Text>
                 </>
               )}
             </Group>


### PR DESCRIPTION
Addresses a user feedback that they can't easily distinguish which document bundles are up-to-date vs not.