### PR TITLE
Adapt CI to versioned release: only deploy on tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: "CI"
 on:
   push:
     branches: [ master ]
+    tags: [ 'v*.edi*' ]
   pull_request:
     branches: [ master ]
 
@@ -108,9 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     container: node:24
     needs: determine-changes
-    # Only run for pull requests, since on pushes to the default branch, the
-    # Docker image building step will run the frontend build anyway.
-    if: ${{ (needs.determine-changes.outputs.frontend == 'true') && (github.event_name == 'pull_request') }}
+    if: ${{ needs.determine-changes.outputs.frontend == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -144,12 +143,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Run this jobas long as the previous jobs have not failed or been cancelled
-    # (allow skips).
-    # Don't run on pull requests, only on pushes to the default branch
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) }}
+    # Run this job only for tagged pushes.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 
-    # Requires all tests and build checks to pass
+    # Requires all tests and build checks to pass.
     needs: [tests, typecheck-lint]
 
     # Job token must have write permissions to the registry
@@ -205,7 +202,7 @@ jobs:
     # pushes to the default branch (master). This job would probably also run on
     # forked repository's default branches, but they wouldn't have access to the
     # production secrets that's set in the GitHub repository settings UI.
-    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
     environment: production
     steps:
       # Fetch the current commit SHA from the production site to include in


### PR DESCRIPTION
Previously every push to master triggered a deployment. Now as upstream uses versioned releases, we will as well, and deployments will only happen for new tags matching the `v*.edi*` pattern, e.g. `v2026.04.edi0`.