### PR TITLE
Rewrite changelog to prepare changing version number scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,18 @@
 ## v2026.04.edi2
 
 - Fixed labels overlapping in grade stats graphs (#94)
+- Next version onwards will be tagged as vYYYY.MM.DD(-\<id>)
 
 ## v2026.04.edi1
 
 - Fixed visual regressions from previous version
 - Added last edit time of documents in the course page (by user request)
 
-## v2026.04.edi0 (Based on upstream v2026.04.p0)
+## v2026.04.edi0
 
-- Merged all changes from upstream up to v2026.04.p0. See below for changelog  (#86).
+(This release is based on upstream v2026.04.p0)
 
-## v2026.04.p0 - Coding Weekend!
+- Merged all changes from upstream up to and including v2026.04.p0. See below for changelog (#86).
 
 ### Added
 
@@ -29,14 +30,21 @@
 - Delete exam button in modqueue (!652)
 - Support for setting homeorg to something other than ethz.ch (!639)
 - Support for .xlsx, .csv, .ods document formats (!628)
+- Support for Typst files when uploading documents (!618)
+- Auto-generated API documentation using Django Ninja (!614)
+- Mermaid explanations in supported functions (!617)
+- Backend support for official answers in exams (!429)
+- Caching parts of the home page improving load times (!545)
 
 ### Changed
 
 - Upgrade Yarn from v1 to v4 (!636, !654)
-- Upgrade react-router from v6 to v7 (!635)
+- Upgrade react-router from v5 to v7 (!579, !635)
 - Upgrade UI library (Mantine) from v8 to v9 (!658)
 - Upgrade dependencies: vite (!620), typescript (!631), pdfjs (!632), react-syntax-highlighter (!670), faro-react (!666)
 - Rewrote Images API to be OpenAPI-compliant (!656)
+- Migrated Node LTS to v24 (!619)
+- Migrated ahooks to v2 (!615)
 
 ### Fixed
 
@@ -46,32 +54,13 @@
 - Tons of requests firing off in home page (!664)
 - Overflowing text editor icons on mobile (!647)
 - Various frontend linter warnings (!629, !630, !673)
-
-Many thanks to contributors Luca, Yuto, Burak, Severin, Marius, Jacques, Metehan, Bogdan, Clemens, and Emily.
-
-## v2026.03.p0
-
-### Added
-
-- Support for Typst files when uploading documents (!618)
-- Auto-generated API documentation using Django Ninja (!614)
-- Mermaid explanations in supported functions (!617)
-- Backend support for official answers in exams (!429)
-- Caching parts of the home page improving load times (!545)
-
-### Changed
-
-- Migrated Node LTS to v24 (!619)
-- Migrated React Router to v6 (!579)
-- Migrated ahooks to v2 (!615)
-
-### Fixed
-
 - Auth token flagged as expired before expiry time due to timezone offset handling (!612)
 - Cannot select text from the source code of supported markdown functions (!616)
 - List meta categories getting called separately for each meta category (!623)
 - Failing to use refresh token due to not passing the scope variable to Keycloak (!624)
 
+Many thanks to contributors Luca, Yuto, Burak, Severin, Marius, Jacques, Metehan, Bogdan, Clemens, and Emily.
+
 ## Previous Changes
 
-The changes before this point were not tagged and don't have a changelog. Check the commit history for more information.
+The changes before this point were not tagged and don't have a changelog. Check the commit history or pull request history on GitHub for more information.


### PR DESCRIPTION
The edi0...ediN numbering scheme for versioned releases did not make a lot of sense, since it downplayed large changes local to our fork by giving it a patch number instead of any major version bump.

Rather, we switch to versioning our fork independent to upstream, with our own YYYY.MM.DD CalVer scheme that has no distinction between patches, upstream merges, or our own features. An optional incremental ID component (starting from 1) is reserved for deduplicating any releases made on the same day.

Past tags will not be retroactively updated. Only future tags will be affected. This PR adds a note for it.

Additionally, this PR also removes upstream-specific changelog entries. All versions listed as headings in CHANGELOG.md refers to a specific Better Informatics tag. Where a tag contained changes from multiple upstream tags, the changelog entries were combined.