### PR TITLE
Fix scroll bar showing up when clicking on category page tabs

### DIFF
--- a/frontend/src/pages/category-page.tsx
+++ b/frontend/src/pages/category-page.tsx
@@ -285,6 +285,7 @@ const CategoryPageContent: React.FC<CategoryPageContentProps> = ({
                   style={{
                     overflowX:
                       "auto" /* Allow scrolling tabs if they overflow */,
+                    overflowY: "hidden",
                   }}
                 >
                   {tabs.Component}

--- a/frontend/src/pages/category-page.tsx
+++ b/frontend/src/pages/category-page.tsx
@@ -285,7 +285,7 @@ const CategoryPageContent: React.FC<CategoryPageContentProps> = ({
                   style={{
                     overflowX:
                       "auto" /* Allow scrolling tabs if they overflow */,
-                    overflowY: "hidden",
+                    overflowY: "hidden" /* Hide vertical scrollbars */,
                   }}
                 >
                   {tabs.Component}


### PR DESCRIPTION
Closes #54.

## Before:
[Before](https://github.com/user-attachments/assets/102a8bf9-fba2-4e31-ab2a-d8179665848c)

## After:
[Screencast from 25-05-26 20:41:42.webm](https://github.com/user-attachments/assets/faa0b1de-0146-4bc9-af1d-f8c8fa62548a)
