### PR TITLE
Fix changelog generator modifying past release entries

### DIFF
--- a/.github/workflows/release_pr_command.yaml
+++ b/.github/workflows/release_pr_command.yaml
@@ -117,8 +117,8 @@ jobs:
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' ONLY_NEW.md
 
           # Add paranthesis around issue/PR links
-          sed -i 's/\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
-          sed -i 's/\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
+          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
+          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
 
           echo "raw_new<<EOF" >> "$GITHUB_OUTPUT"
           cat ONLY_NEW.md >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release_pr_creator.yaml
+++ b/.github/workflows/release_pr_creator.yaml
@@ -156,8 +156,8 @@ jobs:
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' ONLY_NEW.md
 
           # Add paranthesis around issue/PR links
-          sed -i 's/\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
-          sed -i 's/\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
+          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
+          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
 
           {
             echo 'raw_new<<CI_RAW_CHANGELOG_NEW'


### PR DESCRIPTION
The automatic changelog generator for the upcoming release is modifying past entries in the changelog due to a faulty `sed` match. Transforms should be idempotent, which it wasn't. This PR fixes it.