### PR TITLE
Improve the PR description for auto-generated changelog PRs

### DIFF
--- a/.github/workflows/release_pr_command.yaml
+++ b/.github/workflows/release_pr_command.yaml
@@ -111,12 +111,16 @@ jobs:
           head -n -3 ONLY_NEW.md > temp.txt
           mv temp.txt ONLY_NEW.md
 
+          # Remove top heading and newlines from ONLY_NEW (first 2 lines)
+          tail -n +3 ONLY_NEW.md > temp.txt
+          mv temp.txt ONLY_NEW.md
+
           # Remove links (## [abc](..) -> abc) from the headers
           # This is not customisable in github-changelog-generator
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' CHANGELOG.md
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' ONLY_NEW.md
 
-          # Add paranthesis around issue/PR links
+          # Add parenthesis around issue/PR links
           sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
           sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
 

--- a/.github/workflows/release_pr_command.yaml
+++ b/.github/workflows/release_pr_command.yaml
@@ -142,7 +142,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           raw_body="${{ steps.changelog.outputs.raw_new }}"
-          printf '%s\n' '<table>' '<tbody>' '<tr>' '<td>' '' "$raw_body" '' '</td>' '</tr>' '</tbody>' '</table>' '' 'This PR auto-rebases when the master branch ref is updated.' '' 'Comment "/release v<version number>" when it is time to release the next version.' 'This will mark the PR as Ready and regenerate the changelog with the specified version. (Note that this will overwrite any manual commits.)' 'Finally, squash-merge this PR to create the release.' > pr-body.txt
+          printf '%s\n' '<table><tbody><tr><td>' '' "$raw_body" '' '</td></tr></tbody></table>' '' 'This PR tracks the upcoming release and keeps an automatically generated changelog for it. It auto-rebases when the master branch ref is updated.' '' 'Comment "/release v<version number>" when it is time to release the next version.' 'This will mark the PR as Ready and regenerate the changelog with the specified version. (Note that this will overwrite any manual commits.)' 'After "/release", you can manually edit the changelog if necessary.' 'Finally, squash-merge this PR to create the release.' > pr-body.txt
 
           gh pr edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/release_pr_creator.yaml
+++ b/.github/workflows/release_pr_creator.yaml
@@ -150,12 +150,16 @@ jobs:
           head -n -3 ONLY_NEW.md > temp.txt
           mv temp.txt ONLY_NEW.md
 
+          # Remove top heading and newlines from ONLY_NEW (first 2 lines)
+          tail -n +3 ONLY_NEW.md > temp.txt
+          mv temp.txt ONLY_NEW.md
+
           # Remove links (## [abc](..) -> abc) from the headers
           # This is not customisable in github-changelog-generator
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' CHANGELOG.md
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' ONLY_NEW.md
 
-          # Add paranthesis around issue/PR links
+          # Add parenthesis around issue/PR links
           sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
           sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
 

--- a/.github/workflows/release_pr_creator.yaml
+++ b/.github/workflows/release_pr_creator.yaml
@@ -186,19 +186,14 @@ jobs:
           git push --force origin next-release
 
           cat > pr-body.txt <<'EOF'
-          <table>
-          <tbody>
-          <tr>
-          <td>
+          <table><tbody><tr><td>
 
           ${{ steps.changelog.outputs.raw_new }}
 
-          </td>
-          </tr>
-          </tbody>
-          </table>
+          </td></tr></tbody></table>
 
-          This PR auto-rebases when the master branch ref is updated.
+          This PR tracks the upcoming release and keeps an automatically generated
+          changelog for it. It auto-rebases when the master branch ref is updated.
 
           Comment `/release v<version number>` when it is time to release the next version.
           This will mark the PR as Ready and regenerate the changelog with the specified version.


### PR DESCRIPTION
We remove the top-level 'Changelog' heading since it's redundant, add a sentence about what the PR is for, and compact HTML lines together where we can to avoid superfluous linebreaks in Discord notifications of pull requests.