### PR TITLE
Fix sed removing preceding character in auto-generated changelog

### DIFF
--- a/.github/workflows/release_pr_command.yaml
+++ b/.github/workflows/release_pr_command.yaml
@@ -121,8 +121,8 @@ jobs:
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' ONLY_NEW.md
 
           # Add parenthesis around issue/PR links
-          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
-          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
+          sed -i 's/\([^(]\)\(\[\\#[0-9]\+\]([^ ]*)\)/\1(\2)/g' CHANGELOG.md
+          sed -i 's/\([^(]\)\(\[\\#[0-9]\+\]([^ ]*)\)/\1(\2)/g' ONLY_NEW.md
 
           echo "raw_new<<EOF" >> "$GITHUB_OUTPUT"
           cat ONLY_NEW.md >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release_pr_creator.yaml
+++ b/.github/workflows/release_pr_creator.yaml
@@ -160,8 +160,8 @@ jobs:
           sed -i 's/## \[\(.*\)\](.*)/## \1/g' ONLY_NEW.md
 
           # Add parenthesis around issue/PR links
-          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' CHANGELOG.md
-          sed -i 's/[^(]\(\[\\#[0-9]\+\]([^ ]*)\)/(\1)/g' ONLY_NEW.md
+          sed -i 's/\([^(]\)\(\[\\#[0-9]\+\]([^ ]*)\)/\1(\2)/g' CHANGELOG.md
+          sed -i 's/\([^(]\)\(\[\\#[0-9]\+\]([^ ]*)\)/\1(\2)/g' ONLY_NEW.md
 
           {
             echo 'raw_new<<CI_RAW_CHANGELOG_NEW'


### PR DESCRIPTION
The `sed` command when auto-generating changelogs was removing one character that preceded links to pull requests. This was due to us checking if the preceding character was a bracket (for #102) and forgetting to put that character back into the string.

We fix by adding a new capture group for the first character (\1).

Yes, `'s/\([^(]\)\(\[\\#[0-9]\+\]([^ ]*)\)/\1(\2)/g'` is ugly. We live with it.