### PR TITLE
Slimmer navigation bar

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -240,7 +240,7 @@ const App: React.FC = () => {
   ];
 
   const bottomHeaderNav = [
-    { title: "Home", href: "/" },
+    { title: "Courses", href: "/" },
     { title: "Dissertations", href: "/dissertations" },
     {
       title: "More",

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -13,7 +13,7 @@ import {
 import chroma from "chroma-js";
 import "@mantine/core/styles.css";
 import "@mantine/charts/styles.css";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import tinycolor from "tinycolor2";
 import { authenticated, fetchGet, getCookie } from "./api/fetch-utils";
@@ -59,6 +59,7 @@ import {
   QuickSearchFilterContext,
 } from "./components/Navbar/QuickSearch/QuickSearchFilterContext";
 import { useScrollToHash } from "./hooks/useScrollToHash";
+import ExternalNavElement from "./components/Navbar/ExternalNav";
 
 export function calculateShades(color: string): MantineColorsTuple {
   const LIGHTNESS_MAP = [
@@ -252,18 +253,28 @@ const App: React.FC = () => {
         ...(typeof user === "object" && user.isCategoryAdmin ? adminItems : []),
       ],
     },
-    {
-      title: (
-        <Indicator
-          disabled={unreadCount === undefined || unreadCount === 0}
-          label={unreadCount}
-        >
-          Account
-        </Indicator>
-      ),
-      href: `/user/${user?.username}`,
-    },
   ];
+
+  const loginButton = useMemo(
+    () => (
+      <ExternalNavElement
+        isExternal={false}
+        mobile={false}
+        item={{
+          title: (
+            <Indicator
+              disabled={unreadCount === undefined || unreadCount === 0}
+              label={unreadCount}
+            >
+              {user?.username ?? "Login"}
+            </Indicator>
+          ),
+          href: `/user/${user?.username}`,
+        }}
+      />
+    ),
+    [user, unreadCount],
+  );
 
   // Change CSS variables depending on the color scheme in use
   const resolver: CSSVariablesResolver = _ => ({
@@ -303,12 +314,14 @@ const App: React.FC = () => {
                   title={"File Collection"}
                   size="xl"
                   icon={configOptions.logo}
+                  loginButton={loginButton}
                 />
                 <MobileHeader
                   signet={configOptions.logo ?? defaultConfigOptions.logo}
                   selectedLanguage={"en"}
                   appNav={bottomHeaderNav}
                   title={"File Collection"}
+                  loginButton={loginButton}
                 />
                 <AnnouncementHeader />
                 <Box component="main" mt="2em">

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -266,10 +266,10 @@ const App: React.FC = () => {
               disabled={unreadCount === undefined || unreadCount === 0}
               label={unreadCount}
             >
-              {user?.username ?? "Login"}
+              {user?.loggedin ? user.username : "Login"}
             </Indicator>
           ),
-          href: `/user/${user?.username}`,
+          href: user?.loggedin ? `/user/${user.username}` : "/login",
         }}
       />
     ),

--- a/frontend/src/components/Navbar/BottomHeader.module.css
+++ b/frontend/src/components/Navbar/BottomHeader.module.css
@@ -41,3 +41,24 @@
   font-size: 1.25rem;
   color: inherit; /* don't try to apply default mantine link styles */
 }
+
+.navItem {
+  /** Non-Mobile-specific styles. For common styles between MobileHeader and
+   * BottomHeader, put it in ExternalNav.module.css.
+   */
+
+  line-height: 2.5rem;
+  padding-bottom: 2px;
+  margin-bottom: -2px;
+  padding-inline: 0.25rem;
+  opacity: 0.8;
+
+  &:hover {
+    opacity: 1;
+    border-bottom: solid 2px var(--mantine-primary-color-filled);
+  }
+
+  &:global(.active) {
+    border-bottom: solid 2px var(--mantine-primary-color-filled);
+  }
+}

--- a/frontend/src/components/Navbar/BottomHeader.module.css
+++ b/frontend/src/components/Navbar/BottomHeader.module.css
@@ -1,9 +1,9 @@
 .placeholder {
-  height: 3.5rem;
+  height: 2.5rem;
 }
 
 .navbar {
-  height: 3.5rem;
+  height: 2.5rem;
   box-sizing: border-box;
   border-bottom: 2px solid var(--mantine-color-gray-2);
   color: var(--mantine-color-anchor);
@@ -25,13 +25,12 @@
 .container {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   flex-wrap: nowrap;
   height: 100%;
 }
 
 .logo {
-  height: 2rem;
+  height: 1.5rem;
   padding-right: 1.25rem;
 }
 

--- a/frontend/src/components/Navbar/BottomHeader.module.css
+++ b/frontend/src/components/Navbar/BottomHeader.module.css
@@ -41,24 +41,3 @@
   font-size: 1.25rem;
   color: inherit; /* don't try to apply default mantine link styles */
 }
-
-.navItem {
-  /** Non-Mobile-specific styles. For common styles between MobileHeader and
-   * BottomHeader, put it in ExternalNav.module.css.
-   */
-
-  line-height: 2.5rem;
-  padding-bottom: 2px;
-  margin-bottom: -2px;
-  padding-inline: 0.25rem;
-  opacity: 0.8;
-
-  &:hover {
-    opacity: 1;
-    border-bottom: solid 2px var(--mantine-primary-color-filled);
-  }
-
-  &:global(.active) {
-    border-bottom: solid 2px var(--mantine-primary-color-filled);
-  }
-}

--- a/frontend/src/components/Navbar/BottomHeader.tsx
+++ b/frontend/src/components/Navbar/BottomHeader.tsx
@@ -56,10 +56,11 @@ const BottomHeader: React.FC<Props> = ({
                   mobile={false}
                   isExternal={false}
                   key={i}
+                  titleClassName={classes.navItem}
                 />
               );
             })}
-            <QuickSearchBox/>
+            <QuickSearchBox />
             {loginButton}
           </Group>
           <ColorSchemeToggle />

--- a/frontend/src/components/Navbar/BottomHeader.tsx
+++ b/frontend/src/components/Navbar/BottomHeader.tsx
@@ -46,11 +46,9 @@ const BottomHeader: React.FC<Props> = ({
                 />
               )
             )}
-            {title}
           </Link>
 
-          <Group justify="flex-end" wrap="nowrap" gap="2.75rem">
-            <QuickSearchBox />
+          <Group wrap="nowrap" gap="0.5rem" align="center" h="100%" flex="1">
             {translate(appNav, lang).map((item, i) => {
               return (
                 <ExternalNavElement
@@ -61,9 +59,10 @@ const BottomHeader: React.FC<Props> = ({
                 />
               );
             })}
+            <QuickSearchBox/>
             {loginButton}
-            <ColorSchemeToggle />
           </Group>
+          <ColorSchemeToggle />
         </Container>
       </Box>
     </>

--- a/frontend/src/components/Navbar/ExternalNav.module.css
+++ b/frontend/src/components/Navbar/ExternalNav.module.css
@@ -18,7 +18,23 @@
   box-sizing: border-box;
   border: solid 2px transparent;
   flex: 0;
-  /* transition: border-bottom 0.1s linear, opacity 0.1s linear; */
+
+  @media (min-width: $mantine-breakpoint-md) {
+    line-height: 2.5rem;
+    padding-bottom: 2px;
+    margin-bottom: -2px;
+    padding-inline: 0.25rem;
+    opacity: 0.8;
+
+    &:hover {
+      opacity: 1;
+      border-bottom: solid 2px var(--mantine-primary-color-filled);
+    }
+
+    &:global(.active) {
+      border-bottom: solid 2px var(--mantine-primary-color-filled);
+    }
+  }
 
   @media (max-width: $mantine-breakpoint-md) {
     text-align: left;

--- a/frontend/src/components/Navbar/ExternalNav.module.css
+++ b/frontend/src/components/Navbar/ExternalNav.module.css
@@ -52,8 +52,6 @@
   cursor: pointer;
   fill: rgba(51, 51, 51, 0.5);
   border-radius: var(--mantine-radius-sm);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
   border: solid 2px transparent;
   border-left: solid 2px transparent;
   opacity: 0.8;

--- a/frontend/src/components/Navbar/ExternalNav.module.css
+++ b/frontend/src/components/Navbar/ExternalNav.module.css
@@ -13,10 +13,30 @@
    * mode even on dark background
    */
   color: inherit;
+  opacity: 0.8;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  border: solid 2px transparent;
+  padding-bottom: 2px;
+  margin-bottom: -2px;
+  padding-inline: 0.25rem;
+  flex: 0;
+  /* transition: border-bottom 0.1s linear, opacity 0.1s linear; */
 
   @media (max-width: $mantine-breakpoint-md) {
     text-align: left;
     display: block;
+  }
+
+  &:hover {
+    opacity: 1;
+    border-bottom: solid 2px var(--mantine-primary-color-filled);
+  }
+
+  &:global(.active) {
+    border-bottom: solid 2px var(--mantine-primary-color-filled);
   }
 }
 
@@ -29,16 +49,26 @@
   line-height: 1rem !important;
   cursor: pointer;
   fill: rgba(51, 51, 51, 0.5);
-}
+  border-radius: var(--mantine-radius-sm);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border: solid 2px transparent;
+  border-left: solid 2px transparent;
+  opacity: 0.8;
 
+  &:hover {
+    opacity: 1;
+    border-left: solid 2px var(--mantine-primary-color-filled);
+  }
+
+  &:global(.active) {
+    border-left: solid 2px var(--mantine-primary-color-filled);
+  }
+}
 
 .link {
   text-decoration: none !important;
   width: 100%;
-}
-
-.active {
-  border-bottom: solid 0.25rem rgba(255, 255, 255, 0.8);
 }
 
 .mobileChild {

--- a/frontend/src/components/Navbar/ExternalNav.module.css
+++ b/frontend/src/components/Navbar/ExternalNav.module.css
@@ -5,7 +5,6 @@
   display: initial;
   cursor: pointer;
   font-size: 1rem;
-  line-height: 2.5rem;
   white-space: nowrap;
   font-weight: 500;
   /* don't use mantine-color-anchor (applied to all Anchor elements) but instead
@@ -13,30 +12,17 @@
    * mode even on dark background
    */
   color: inherit;
-  opacity: 0.8;
   height: 100%;
   display: flex;
   align-items: center;
   box-sizing: border-box;
   border: solid 2px transparent;
-  padding-bottom: 2px;
-  margin-bottom: -2px;
-  padding-inline: 0.25rem;
   flex: 0;
   /* transition: border-bottom 0.1s linear, opacity 0.1s linear; */
 
   @media (max-width: $mantine-breakpoint-md) {
     text-align: left;
     display: block;
-  }
-
-  &:hover {
-    opacity: 1;
-    border-bottom: solid 2px var(--mantine-primary-color-filled);
-  }
-
-  &:global(.active) {
-    border-bottom: solid 2px var(--mantine-primary-color-filled);
   }
 }
 

--- a/frontend/src/components/Navbar/ExternalNav.module.css
+++ b/frontend/src/components/Navbar/ExternalNav.module.css
@@ -4,9 +4,8 @@
   text-align: right;
   display: initial;
   cursor: pointer;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-  text-transform: uppercase;
+  font-size: 1rem;
+  line-height: 2.5rem;
   white-space: nowrap;
   font-weight: 500;
   /* don't use mantine-color-anchor (applied to all Anchor elements) but instead
@@ -21,12 +20,17 @@
   }
 }
 
+.navItem:last-child {
+  margin-left: auto;
+}
+
 .childItem {
   font-size: 1rem !important;
-  line-height: 1.5rem !important;
+  line-height: 1rem !important;
   cursor: pointer;
   fill: rgba(51, 51, 51, 0.5);
 }
+
 
 .link {
   text-decoration: none !important;

--- a/frontend/src/components/Navbar/ExternalNav.tsx
+++ b/frontend/src/components/Navbar/ExternalNav.tsx
@@ -40,7 +40,13 @@ const ExternalNavElement: React.FC<Props> = ({
         ))}
       </>
     ) : (
-      <Menu position="bottom-end" closeOnItemClick={true} width={200} offset={0}>
+      <Menu
+        position="bottom-start"
+        closeOnItemClick={true}
+        width={200}
+        offset={0}
+        trigger="click-hover"
+      >
         <Menu.Target>
           <Anchor
             component="div"

--- a/frontend/src/components/Navbar/ExternalNav.tsx
+++ b/frontend/src/components/Navbar/ExternalNav.tsx
@@ -40,7 +40,7 @@ const ExternalNavElement: React.FC<Props> = ({
         ))}
       </>
     ) : (
-      <Menu position="bottom-end" closeOnItemClick={true} width={200}>
+      <Menu position="bottom-end" closeOnItemClick={true} width={200} offset={0}>
         <Menu.Target>
           <Anchor
             component="div"
@@ -48,7 +48,6 @@ const ExternalNavElement: React.FC<Props> = ({
             className={clsx(classes.navItem, classes.link, textClassName)}
             display="flex"
             style={{
-              padding: 0,
               cursor: "pointer",
             }}
           >
@@ -72,7 +71,6 @@ const ExternalNavElement: React.FC<Props> = ({
                 onClick={childItem.onClick}
                 key={i}
                 pl="xs"
-                py="xs"
               >
                 {childItem.title as ReactNode}
               </Menu.Item>
@@ -85,7 +83,6 @@ const ExternalNavElement: React.FC<Props> = ({
                 onClick={childItem.onClick}
                 key={i}
                 pl="xs"
-                py="xs"
               >
                 {childItem.title as ReactNode}
               </Menu.Item>

--- a/frontend/src/components/Navbar/MobileHeader.module.css
+++ b/frontend/src/components/Navbar/MobileHeader.module.css
@@ -1,5 +1,5 @@
 .navbar {
-  min-height: 3.5rem;
+  min-height: 2.5rem;
   color: var(--mantine-color-anchor);
   width: 100%;
   box-sizing: border-box;
@@ -13,22 +13,19 @@
   color: var(--mantine-color-anchor);
 }
 
-.logoLine {
-  padding: 0.75rem 0;
-}
-
 .invertedLogo {
   filter: brightness(0) invert(1);
 }
 
 .logo {
-  height: 2rem;
-  padding-right: 1.25rem;
+  height: 1.5rem;
+  padding-right: 0.5rem;
 }
 
 .title {
   font-weight: 400;
   font-size: 1.25rem;
+  flex: 1;
 }
 
 .separator {

--- a/frontend/src/components/Navbar/MobileHeader.tsx
+++ b/frontend/src/components/Navbar/MobileHeader.tsx
@@ -32,31 +32,28 @@ const BottomHeader: React.FC<Props> = ({
         className={classes.logoLine}
         align="center"
         justify="space-between"
+        gap="0.5rem"
       >
-        <div style={{ display: "flex" }}>
-          {uwu ? (
-            <KawaiiBetterInformatics className={classes.logo} />
-          ) : (
-            <img
-              src={signet}
-              alt="Signet of the student organization"
-              className={classes.logo}
-            />
-          )}
-          <div className={classes.title}>
-            <Link to={""} style={{ color: "inherit", textDecoration: "none" }}>
-              {title}
-            </Link>
-          </div>
-        </div>
-        <Group>
-          <ColorSchemeToggle />
-          <Burger
-            opened={opened}
-            onClick={() => setOpened((o: boolean) => !o)}
-            size="sm"
+        {uwu ? (
+          <KawaiiBetterInformatics className={classes.logo} />
+        ) : (
+          <img
+            src={signet}
+            alt="Signet of the student organization"
+            className={classes.logo}
           />
-        </Group>
+        )}
+        <div className={classes.title}>
+          <Link to={""} style={{ color: "inherit", textDecoration: "none" }}>
+            {title}
+          </Link>
+        </div>
+        <ColorSchemeToggle />
+        <Burger
+          opened={opened}
+          onClick={() => setOpened((o: boolean) => !o)}
+          size="sm"
+        />
       </Group>
       {opened ? (
         <Stack align="flex-start" gap="sm" py="xs">

--- a/frontend/src/components/Navbar/MobileHeader.tsx
+++ b/frontend/src/components/Navbar/MobileHeader.tsx
@@ -56,7 +56,7 @@ const BottomHeader: React.FC<Props> = ({
         />
       </Group>
       {opened ? (
-        <Stack align="flex-start" gap="sm" py="xs">
+        <Stack align="flex-start" gap="xs" py="xs">
           {translate(appNav, selectedLanguage).map((item, i) => {
             return (
               <div key={i} onClick={() => setOpened(false)}>

--- a/frontend/src/components/Navbar/QuickSearch/QuickSearchBox.module.css
+++ b/frontend/src/components/Navbar/QuickSearch/QuickSearchBox.module.css
@@ -1,11 +1,23 @@
 .navButton {
-  background: var(--mantine-color-gray-light);
+  background: var(--mantine-color-default);
   overflow: visible;
-  color: var(--mantine-color-text);
+  color: var(--mantine-color-placeholder);
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  cursor: text;
 
-  &:hover {
+  margin-bottom: -2px;
+  height: calc(100% - var(--mantine-spacing-xs));
+  border-radius: var(--mantine-radius-md);
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--mantine-color-default-border);
+  box-sizing: border-box;
+
+  &:active {
+    border: 1px solid var(--mantine-primary-color-filled);
     background: var(--mantine-color-gray-light-hover);
-    color: var(--mantine-color-text);
   }
 }
 

--- a/frontend/src/components/Navbar/QuickSearch/QuickSearchBox.tsx
+++ b/frontend/src/components/Navbar/QuickSearch/QuickSearchBox.tsx
@@ -21,6 +21,7 @@ import {
   Loader,
   Space,
   UnstyledButton,
+  Badge,
 } from "@mantine/core";
 import {
   getHotkeyHandler,
@@ -281,9 +282,9 @@ export const QuickSearchBox: React.FC = () => {
           <IconSearch />
           <Text size="md">Search...</Text>
           <Space w="md" />
-          <Kbd size="xs" bd="none">
+          <Badge size="xs" radius="xs" variant="default">
             {os === "macos" ? "⌘" : "Ctrl +"} K
-          </Kbd>
+          </Badge>
         </Group>
       </UnstyledButton>
       <Modal

--- a/frontend/src/components/Navbar/QuickSearch/QuickSearchBox.tsx
+++ b/frontend/src/components/Navbar/QuickSearch/QuickSearchBox.tsx
@@ -19,6 +19,8 @@ import {
   Divider,
   Stack,
   Loader,
+  Space,
+  UnstyledButton,
 } from "@mantine/core";
 import {
   getHotkeyHandler,
@@ -110,7 +112,7 @@ export const QuickSearchBox: React.FC = () => {
   const categoryResults = useSearch(
     // Disable category results (with an empty data list) if we're already
     // searching in a single category
-    isGlobal ? categories.data ?? [] : [],
+    isGlobal ? (categories.data ?? []) : [],
     searchQuery,
     // We only really want to show almost-perfect matches for this component.
     // So the max error score we allow is 4 -- this value was found by trial and
@@ -269,13 +271,21 @@ export const QuickSearchBox: React.FC = () => {
 
   return (
     <>
-      <Button className={classes.navButton} px="md" onClick={openWithHighlight}>
+      <UnstyledButton
+        className={classes.navButton}
+        px="xs"
+        onClick={openWithHighlight}
+        size="xs"
+      >
         <Group wrap="nowrap">
           <IconSearch />
-          <span>Search</span>
-          <Kbd>{os === "macos" ? "⌘" : "Ctrl +"} K</Kbd>
+          <Text size="md">Search...</Text>
+          <Space w="md" />
+          <Kbd size="xs" bd="none">
+            {os === "macos" ? "⌘" : "Ctrl +"} K
+          </Kbd>
         </Group>
-      </Button>
+      </UnstyledButton>
       <Modal
         size="82.5rem"
         opened={opened}
@@ -284,7 +294,7 @@ export const QuickSearchBox: React.FC = () => {
         fullScreen={isMobile}
         transitionProps={{
           transition: "pop",
-          duration: 100,
+          duration: 0,
           timingFunction: "cubic-bezier(0.5, 1, 0.89, 1)", // easeOutQuad
         }}
         // The height of top nav

--- a/frontend/src/components/color-scheme-toggle.tsx
+++ b/frontend/src/components/color-scheme-toggle.tsx
@@ -8,20 +8,51 @@ import {
 import { IconMoon, IconSun, IconSunMoon } from "@tabler/icons-react";
 
 const ColorSchemeToggle = () => {
-  const { colorScheme, setColorScheme, clearColorScheme } = useMantineColorScheme();
+  const { colorScheme, setColorScheme, clearColorScheme } =
+    useMantineColorScheme();
   return (
     <Group justify="center">
-      <HoverCard shadow="md" withArrow openDelay={100} closeDelay={100} disabled={colorScheme == "auto"}>
+      <HoverCard
+        shadow="md"
+        withArrow
+        openDelay={100}
+        closeDelay={100}
+        disabled={colorScheme == "auto"}
+      >
         <HoverCard.Target>
           <Group>
-            <Button darkHidden variant="transparent" leftSection={<IconMoon />} onClick={() => { setColorScheme("dark") }} />
-            <Button lightHidden variant="transparent" leftSection={<IconSun />} onClick={() => { setColorScheme("light") }} />
+            <Button
+              darkHidden
+              variant="transparent"
+              onClick={() => {
+                setColorScheme("dark");
+              }}
+              pr={0}
+            >
+              <IconMoon />
+            </Button>
+            <Button
+              lightHidden
+              variant="transparent"
+              onClick={() => {
+                setColorScheme("light");
+              }}
+              pr={0}
+            >
+              <IconSun />
+            </Button>
           </Group>
         </HoverCard.Target>
         <HoverCard.Dropdown>
           <Group>
             <Text>Follow system theme: </Text>
-            <Button variant="transparent" leftSection={<IconSunMoon />} onClick={() => { setColorScheme("auto") }} />
+            <Button
+              variant="transparent"
+              leftSection={<IconSunMoon />}
+              onClick={() => {
+                setColorScheme("auto");
+              }}
+            />
           </Group>
         </HoverCard.Dropdown>
       </HoverCard>


### PR DESCRIPTION
As more content is due to arrive in Better Informatics over the coming months and thus more items will be on the navigation bar, I thought we could do with a little restyling to slim down the navigation bar vertically (from 3.5rem to 2.5rem).

Some specific points that were changed are:
- If logged in, the specific logged-in username is shown instead of "Account"
- Titlecase is preferred over UPPERCASE for easier scanning
- "File Collection" text has been removed to prepare for an upcoming consolidation of BI and BI FC.

<img width="1920" height="418" alt="msedge_2026-05-31_00-05-17" src="https://github.com/user-attachments/assets/b8fe4764-6ad3-44ef-8e2b-e2754fa8007f" />

<img width="1920" height="410" alt="msedge_2026-05-31_00-05-34" src="https://github.com/user-attachments/assets/5592e540-faf0-4aff-9dc5-2bd4f7b8352e" />
