### PR TITLE
Show number of active student users in stats page

### DIFF
--- a/backend/stats/views.py
+++ b/backend/stats/views.py
@@ -2,8 +2,15 @@ from datetime import timedelta
 
 from django.contrib.auth.models import User
 from django.utils import timezone
-from django.db.models import Count, Min, OuterRef, Subquery
-from django.db.models.functions import TruncDate
+from django.db.models import (
+    Count,
+    DateField,
+    ExpressionWrapper,
+    Min,
+    OuterRef,
+    Subquery,
+)
+from django.db.models.functions import Coalesce, TruncDate
 
 from ediauth import auth_check
 from util import response, func_cache
@@ -43,13 +50,45 @@ def get_stats():
         .order_by("day")
     )
     user_counts = {row["day"]: row["cnt"] for row in user_rows}
+
+    disabled_user_rows = (
+        # Based on their last login date, add 250 days to it and annotate the
+        # day that they get disabled. Group by this date, filter out anything
+        # in the future, and count how many users were considered no  longer
+        # active on each day.
+        # For those with last login set to NULL, use their date joined instead.
+        # (250 was chosen as a slightly arbitrary cutoff that isn't as long as
+        # a full year but is long enough to cover two semesters)
+        User.objects.annotate(
+            day=TruncDate(
+                ExpressionWrapper(
+                    Coalesce("last_login", "date_joined") + timedelta(days=250),
+                    output_field=DateField(),
+                )
+            )
+        )
+        .filter(day__lte=timezone.now().date())
+        .values("day")
+        .annotate(cnt=Count("id"))
+        .values("day", "cnt")
+        .order_by("day")
+    )
+    disabled_user_counts = {row["day"]: row["cnt"] for row in disabled_user_rows}
+
     stats["user_stats"] = []
     last_user_count = 0
+    last_disabled_user_count = 0
     for day in days:
         if day in user_counts:
             last_user_count += user_counts[day]
+        if day in disabled_user_counts:
+            last_disabled_user_count += disabled_user_counts[day]
         stats["user_stats"].append(
-            {"date": day.strftime("%Y-%m-%d"), "count": last_user_count}
+            {
+                "date": day.strftime("%Y-%m-%d"),
+                "count": last_user_count,
+                "active_count": last_user_count - last_disabled_user_count,
+            }
         )
 
     answer_rows = (

--- a/backend/stats/views.py
+++ b/backend/stats/views.py
@@ -51,11 +51,11 @@ def get_stats():
     )
     user_counts = {row["day"]: row["cnt"] for row in user_rows}
 
-    disabled_user_rows = (
+    inactive_user_rows = (
         # Based on their last login date, add 250 days to it and annotate the
-        # day that they get disabled. Group by this date, filter out anything
-        # in the future, and count how many users were considered no  longer
-        # active on each day.
+        # day that they are officially considered inactive. Group by this date,
+        # filter out anything in the future, and count how many users were added
+        # each day.
         # For those with last login set to NULL, use their date joined instead.
         # (250 was chosen as a slightly arbitrary cutoff that isn't as long as
         # a full year but is long enough to cover two semesters)
@@ -73,21 +73,21 @@ def get_stats():
         .values("day", "cnt")
         .order_by("day")
     )
-    disabled_user_counts = {row["day"]: row["cnt"] for row in disabled_user_rows}
+    inactive_user_counts = {row["day"]: row["cnt"] for row in inactive_user_rows}
 
     stats["user_stats"] = []
     last_user_count = 0
-    last_disabled_user_count = 0
+    last_inactive_user_count = 0
     for day in days:
         if day in user_counts:
             last_user_count += user_counts[day]
-        if day in disabled_user_counts:
-            last_disabled_user_count += disabled_user_counts[day]
+        if day in inactive_user_counts:
+            last_inactive_user_count += inactive_user_counts[day]
         stats["user_stats"].append(
             {
                 "date": day.strftime("%Y-%m-%d"),
                 "count": last_user_count,
-                "active_count": last_user_count - last_disabled_user_count,
+                "active_count": last_user_count - last_inactive_user_count,
             }
         )
 

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -441,6 +441,7 @@ export interface Stats {
 export interface UserStat {
   date: string;
   count: number;
+  active_count: number;
 }
 
 export interface ExamStat {

--- a/frontend/src/pages/scoreboard-page.tsx
+++ b/frontend/src/pages/scoreboard-page.tsx
@@ -188,7 +188,9 @@ const Scoreboard: React.FC = () => {
       statOptions(
         stats?.user_stats.map(s => s.date) ?? [],
         {
-          "User Count": stats?.user_stats.map(s => s.count) ?? [],
+          "Cumulative User Count": stats?.user_stats.map(s => s.count) ?? [],
+          "Active Student User Count":
+            stats?.user_stats.map(s => s.active_count) ?? [],
         },
         theme.colors[theme.primaryColor],
       ),
@@ -263,6 +265,10 @@ const Scoreboard: React.FC = () => {
           // notMerge is required for dynamic setTheme calls
           notMerge={true}
         />
+        <Text mt="sm" c="dimmed">
+          Note: An Active Student User is defined as a user who has logged in in
+          the last 250 days from the date of interest.
+        </Text>
       </Container>
       <Title order={2} my="lg">
         Exam Stats


### PR DESCRIPTION
Showing only cumulative user stats wasn't very useful since the graph was going to be monotonically increasing anyway. Much more useful was the concept of "active users". Ideally, we'd see a growth over the first few years that BI was deployed, then maintain a roughly constant amount of active users for all future years. If this value is seeing a downward trend, it gives a quick indicator that Better Informatics is losing momentum.

I have arbitrarily decided to record active student users as those who have logged in within the last 250 calendar days. I felt that 365 days was too long (a graduated user will show as active until the following May!) while it needed to be longer than 180 days to cover the period between the two semester exam periods.
