### PR TITLE
Migrate Dissertation pages from ahooks to React Query

### DIFF
--- a/backend/dissertations/api.py
+++ b/backend/dissertations/api.py
@@ -41,6 +41,12 @@ class DissertationSchema(ModelSchema):
     upload_date: str = Field(..., alias="upload_date.isoformat")
     relevant_categories: list[SlugDisplayNameSchema]
     can_edit: bool
+    id: int  # Explicitly include ID due to vitalik/django-ninja#1160
+    year: int  # Explicitly include year due to vitalik/django-ninja#1160
+    grade_band: (
+        str | None
+    )  # Explicitly include grade_band due to vitalik/django-ninja#1160
+    notes: str | None  # Explicitly include notes due to vitalik/django-ninja#1160
 
     @staticmethod
     def resolve_relevant_categories(
@@ -60,15 +66,11 @@ class DissertationSchema(ModelSchema):
     class Meta:
         model = Dissertation
         fields = [
-            "id",
             "title",
             "field_of_study",
             "supervisors",
-            "notes",
             "file_path",
             "study_level",
-            "grade_band",
-            "year",
         ]
 
 
@@ -120,6 +122,13 @@ def redact_file(file: UploadedFile, words_to_redact: list[str]) -> str:
     """
     handle, temp_file_path = tempfile.mkstemp(dir=settings.COMSOL_UPLOAD_FOLDER)
 
+    if not words_to_redact:
+        # If no words to redact, just copy the file to the handle
+        with os.fdopen(handle, "wb") as temp_file:
+            for chunk in file.chunks():
+                temp_file.write(chunk)
+        return temp_file_path
+
     options = RedactorOptions()
     options.content_filters = [
         # Replace each phrase with some periods.
@@ -152,10 +161,13 @@ def upload_dissertation(
     grade_band = data.grade_band
     year = data.year
 
-    temp_file_path = redact_file(
-        pdf_file,
-        [w.strip() for w in (data.words_to_redact or "").split(",") if w.strip()],
-    )
+    try:
+        temp_file_path = redact_file(
+            pdf_file,
+            [w.strip() for w in (data.words_to_redact or "").split(",") if w.strip()],
+        )
+    except Exception as e:
+        return response.not_possible(f"Error redacting file: {str(e)}")
 
     # Upload PDF to Minio
     # Assuming the bucket already exists or is created by Minio setup
@@ -208,14 +220,18 @@ def redact_dissertation(
                 f"Redaction phrase has to be alphanumeric: {word}"
             )
 
-    temp_file_path = redact_file(
-        pdf_file, [w.strip() for w in data.words.split(",") if w.strip()]
-    )
+    try:
+        temp_file_path = redact_file(
+            pdf_file, [w.strip() for w in data.words.split(",") if w.strip()]
+        )
+    except Exception as e:
+        return response.not_possible(f"Error redacting file: {str(e)}")
 
     s3_util.save_file_to_s3(
         bucket_name + "_temp_redacted/",
         f"redacted_{pdf_file.name}",
         temp_file_path,
+        pdf_file.content_type or "application/pdf",
     )
 
     os.remove(temp_file_path)
@@ -358,10 +374,17 @@ def update_dissertation(
             old_file_name = "/".join(old_path_parts[2:])
             s3_util.delete_file(old_bucket_name + "/", old_file_name)
 
-        temp_file_path = redact_file(
-            pdf_file,
-            [w.strip() for w in (data.words_to_redact or "").split(",") if w.strip()],
-        )
+        try:
+            temp_file_path = redact_file(
+                pdf_file,
+                [
+                    w.strip()
+                    for w in (data.words_to_redact or "").split(",")
+                    if w.strip()
+                ],
+            )
+        except Exception as e:
+            return response.not_possible(f"Error redacting file: {str(e)}")
 
         # Upload PDF to Minio
         file_name = f"{dissertation.title.replace(' ', '_')}_{pdf_file.name}"

--- a/backend/dissertations/api.py
+++ b/backend/dissertations/api.py
@@ -41,12 +41,13 @@ class DissertationSchema(ModelSchema):
     upload_date: str = Field(..., alias="upload_date.isoformat")
     relevant_categories: list[SlugDisplayNameSchema]
     can_edit: bool
-    id: int  # Explicitly include ID due to vitalik/django-ninja#1160
-    year: int  # Explicitly include year due to vitalik/django-ninja#1160
+    id: int  # Explicitly include ID since it is known to exist; vitalik/django-ninja#1160
+    year: int  # Explicitly include year since it is known to exist; vitalik/django-ninja#1160
     grade_band: (
         str | None
-    )  # Explicitly include grade_band due to vitalik/django-ninja#1160
-    notes: str | None  # Explicitly include notes due to vitalik/django-ninja#1160
+    )  # Explicitly include grade_band since it is known to exist; vitalik/django-ninja#1160
+    study_level: str  # Explicitly include study_level since it is known to exist; vitalik/django-ninja#1160
+    notes: str  # Explicitly include notes since it is known to exist; vitalik/django-ninja#1160
 
     @staticmethod
     def resolve_relevant_categories(
@@ -70,7 +71,6 @@ class DissertationSchema(ModelSchema):
             "field_of_study",
             "supervisors",
             "file_path",
-            "study_level",
         ]
 
 
@@ -364,6 +364,10 @@ def update_dissertation(
                 return response.not_possible("One or more categories not found.")
             dissertation.relevant_categories.set(categories)
             continue
+
+        # Form fields don't support null so parse "none" as custom value
+        if attr == "grade_band" and value == "none":
+            value = None
         setattr(dissertation, attr, value)
 
     if pdf_file:

--- a/backend/dissertations/api.py
+++ b/backend/dissertations/api.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import re
 import tempfile
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 from django.conf import settings
 from django.db.models import Q
@@ -20,18 +20,15 @@ from ninja import (
 from categories.models import Category
 from ediauth import auth_check
 from util import response, s3_util
+from util.schemas import ValueWrapped
 
 from .models import Dissertation
 from .pdf_redactor import RedactorOptions, redactor
 
 bucket_name = "dissertations"
-router = Router()
+router = Router(tags=["Dissertations"])
 
 T = TypeVar("T")
-
-
-class ValueWrapped(Schema, Generic[T]):
-    value: T
 
 
 class SlugDisplayNameSchema(Schema):
@@ -140,7 +137,9 @@ def redact_file(file: UploadedFile, words_to_redact: list[str]) -> str:
     return temp_file_path
 
 
-@router.post("/", response=ValueWrapped[DissertationSchema])
+@router.post(
+    "/", response=ValueWrapped[DissertationSchema], operation_id="uploadDissertation"
+)
 @auth_check.require_login
 def upload_dissertation(
     request, data: Form[DissertationUploadSchema], pdf_file: File[UploadedFile]
@@ -194,7 +193,7 @@ class DissertationRedactionSchema(Schema):
     words: str  # comma separated, since our frontend doesn't explode arrays
 
 
-@router.post("/redact/", response=ValueWrapped[str])
+@router.post("/redact/", response=ValueWrapped[str], operation_id="redactDissertation")
 @auth_check.require_login
 def redact_dissertation(
     request, pdf_file: File[UploadedFile], data: Form[DissertationRedactionSchema]
@@ -240,7 +239,11 @@ def redact_dissertation(
     return {"value": presigned_url}
 
 
-@router.get("/", response=ValueWrapped[list[DissertationSchema]])
+@router.get(
+    "/",
+    response=ValueWrapped[list[DissertationSchema]],
+    operation_id="listDissertations",
+)
 @auth_check.require_login
 def list_dissertations(
     request,
@@ -281,14 +284,22 @@ def list_dissertations(
     return {"value": dissertations}
 
 
-@router.get("/{dissertation_id}/", response=ValueWrapped[DissertationSchema])
+@router.get(
+    "/{dissertation_id}/",
+    response=ValueWrapped[DissertationSchema],
+    operation_id="getDissertationDetail",
+)
 @auth_check.require_login
 def get_dissertation_detail(request, dissertation_id: int):
     dissertation = get_object_or_404(Dissertation, id=dissertation_id)
     return {"value": dissertation}
 
 
-@router.get("/{dissertation_id}/download/", response=ValueWrapped[str])
+@router.get(
+    "/{dissertation_id}/download/",
+    response=ValueWrapped[str],
+    operation_id="downloadDissertation",
+)
 @auth_check.require_login
 def download_dissertation(request, dissertation_id: int):
     dissertation = get_object_or_404(Dissertation, id=dissertation_id)
@@ -309,7 +320,11 @@ def download_dissertation(request, dissertation_id: int):
     return {"value": presigned_url}
 
 
-@router.put("/{dissertation_id}/", response=ValueWrapped[DissertationSchema])
+@router.put(
+    "/{dissertation_id}/",
+    response=ValueWrapped[DissertationSchema],
+    operation_id="updateDissertation",
+)
 @auth_check.require_login
 def update_dissertation(
     request,
@@ -365,7 +380,7 @@ def update_dissertation(
     return {"value": dissertation}
 
 
-@router.delete("/{dissertation_id}/")
+@router.delete("/{dissertation_id}/", operation_id="deleteDissertation")
 @auth_check.require_login
 def delete_dissertation(request, dissertation_id: int):
     dissertation = get_object_or_404(Dissertation, id=dissertation_id)

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -18,9 +18,6 @@ import {
   SearchResponse,
   AnswerKind,
   BICourseList,
-  DissertationCreate,
-  Dissertation,
-  DissertationUpdate,
 } from "../interfaces";
 import PDF from "../pdf/pdf-renderer";
 import { getDocument } from "../pdf/pdfjs";
@@ -62,8 +59,9 @@ export const useSetUserDisplayUsername = (onSuccess: () => void) => {
 const loadBICourseList = async () => {
   // Use normal fetch() instead of fetchGet as the latter is for internal API
   // and sends some credential cookies
-  return fetch("https://betterinformatics.com/courses.json")
-    .then(r => r.json()) as Promise<BICourseList>;
+  return fetch("https://betterinformatics.com/courses.json").then(r =>
+    r.json(),
+  ) as Promise<BICourseList>;
 };
 
 export const useBICourseList = () => {
@@ -75,7 +73,8 @@ export const useBICourseList = () => {
 
 const loadEnabledNotifications = async (isMyself: boolean) => {
   if (isMyself) {
-    return (await fetchGet(`/api/notification/getenabled/`)).value as NotificationEnabled[];
+    return (await fetchGet(`/api/notification/getenabled/`))
+      .value as NotificationEnabled[];
   } else {
     return undefined;
   }
@@ -90,7 +89,11 @@ export const useEnabledNotifications = (isMyself: boolean) => {
   );
   return [error, loading, data, run] as const;
 };
-const setEnabledNotifications = async (type: number, enabled?: boolean, email_enabled?: boolean) => {
+const setEnabledNotifications = async (
+  type: number,
+  enabled?: boolean,
+  email_enabled?: boolean,
+) => {
   await fetchPost(`/api/notification/setenabled/`, {
     type,
     enabled,
@@ -291,8 +294,13 @@ const updateAnswer = async (
   kind: AnswerKind,
   isAnonymous: boolean = false,
 ) => {
-  return (await fetchPost(`/api/exam/setanswer/${answerId}/`, { text, kind, is_anonymous: isAnonymous }))
-    .value as AnswerSection;
+  return (
+    await fetchPost(`/api/exam/setanswer/${answerId}/`, {
+      text,
+      kind,
+      is_anonymous: isAnonymous,
+    })
+  ).value as AnswerSection;
 };
 const removeAnswer = async (answerId: string) => {
   return (await fetchPost(`/api/exam/removeanswer/${answerId}/`, {}))
@@ -489,7 +497,8 @@ export const useRemoveCategory = (onSuccess?: () => void) =>
 
 // Course Stats
 export const loadCourseStats = async (slug: string) => {
-  return (await fetchGet(`/api/category/stats/${slug}/`)).value as CourseStats[];
+  return (await fetchGet(`/api/category/stats/${slug}/`))
+    .value as CourseStats[];
 };
 
 export const useCourseStats = (slug: string) => {
@@ -533,69 +542,3 @@ export const unmarkExamUserSolved = async (exam: string) => {
 };
 export const useUnmarkExamUserSolved = (exam: string) =>
   useMutation(() => unmarkExamUserSolved(exam));
-
-export const uploadDissertation = async (
-  file: Blob,
-  create_data: DissertationCreate,
-) => {
-  return (await fetchPost<{ value: Dissertation }>("/api/dissertations/", {
-    pdf_file: file,
-    ...create_data,
-  })).value;
-};
-
-export const editDissertation = async (
-  file: Blob | null,
-  id: number,
-  update_data: DissertationUpdate,
-) => {
-  return (await fetchPut<{ value: Dissertation }>(`/api/dissertations/${id}/`, {
-    ...(file ? { pdf_file: file } : {}),
-    ...update_data,
-  })).value;
-};
-
-export const deleteDissertation = async (id: number) => {
-  await fetchDelete(`/api/dissertations/${id}/`);
-};
-
-export const getRedactionPreview = async (
-  file: Blob,
-  words_to_redact: string,
-) => {
-  return (await fetchPost<{ value: string }>("/api/dissertations/redact/", {
-    pdf_file: file,
-    words: words_to_redact,
-  })).value;
-};
-
-export const loadDissertations = async (searchQuery: string, field: string, category?: string) => {
-  return (
-    await fetchGet<{ value: Dissertation[] }>(
-      `/api/dissertations/?${new URLSearchParams({
-        query: searchQuery,
-        field,
-        ...(category ? { category } : {}),
-      }).toString()}`,
-    )
-  ).value;
-};
-
-export const useDissertations = (searchQuery: string, field: string, category?: string) => {
-  const { error, loading, data } = useRequest(
-    () => loadDissertations(searchQuery, field, category),
-    {
-      refreshDeps: [searchQuery, field, category],
-      cacheKey: `dissertations-${field}-${searchQuery}-${category}`,
-    },
-  );
-  return { error, loading, data } as const;
-};
-
-export const loadDissertation = async (id: number) => {
-  return (await fetchGet<{ value: Dissertation }>(`/api/dissertations/${id}/`)).value;
-}
-
-export const loadDissertationPdf = async (id: number) => {
-  return (await fetchGet<{ value: string }>(`/api/dissertations/${id}/download/`)).value;
-}

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -367,7 +367,7 @@ const App: React.FC = () => {
                           element={<DissertationListPage />}
                         />
                         <Route
-                          path="/dissertations/:id"
+                          path="/dissertations/:id/*"
                           element={<DissertationDetailPage />}
                         />
                         <Route path="/faq" element={<FAQ />} />

--- a/frontend/src/components/dissertation-list.tsx
+++ b/frontend/src/components/dissertation-list.tsx
@@ -31,7 +31,7 @@ export const DissertationList: React.FC<Props> = ({ slug, disableSearch }) => {
 
   const {
     data: dissertations,
-    isLoading,
+    isFetching,
     isError,
     error,
   } = useListDissertations(
@@ -51,7 +51,7 @@ export const DissertationList: React.FC<Props> = ({ slug, disableSearch }) => {
 
   // Show larger loading indicator only if it's taking a while - otherwise it's
   // a bit too annoying. there already is a small spinner in the search box.
-  const [loadingDebounced] = useDebouncedValue(isLoading, 500);
+  const [loadingDebounced] = useDebouncedValue(isFetching, 500);
   const rows = useMemo(() => {
     return dissertations
       ? dissertations.map(dissertation => (

--- a/frontend/src/components/dissertation-list.tsx
+++ b/frontend/src/components/dissertation-list.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from "react";
-import { useDissertations } from "../api/hooks";
 import {
   Text,
   Table,
@@ -18,6 +17,7 @@ import {
 import { IconSearch } from "@tabler/icons-react";
 import { useDebouncedValue } from "@mantine/hooks";
 import { Link } from "react-router-dom";
+import { useListDissertations } from "../api/hooks/dissertations";
 
 interface Props {
   slug?: string;
@@ -30,14 +30,28 @@ export const DissertationList: React.FC<Props> = ({ slug, disableSearch }) => {
   const [searchField, setSearchField] = useState<string | null>("title");
 
   const {
-    error,
-    loading,
     data: dissertations,
-  } = useDissertations(debouncedSearchQuery, searchField ?? "", slug);
+    isLoading,
+    isError,
+    error,
+  } = useListDissertations(
+    {
+      query: debouncedSearchQuery,
+      field: searchField ?? "",
+      category: slug,
+    },
+    {
+      query: {
+        select({ value: document }) {
+          return document;
+        },
+      },
+    },
+  );
 
   // Show larger loading indicator only if it's taking a while - otherwise it's
   // a bit too annoying. there already is a small spinner in the search box.
-  const [loadingDebounced] = useDebouncedValue(loading, 500);
+  const [loadingDebounced] = useDebouncedValue(isLoading, 500);
   const rows = useMemo(() => {
     return dissertations
       ? dissertations.map(dissertation => (
@@ -103,7 +117,7 @@ export const DissertationList: React.FC<Props> = ({ slug, disableSearch }) => {
               onChange={event => setSearchQuery(event.currentTarget.value)}
               leftSection={<IconSearch size={16} />}
               rightSection={
-                loading ? (
+                loadingDebounced ? (
                   <Loader size="xs" />
                 ) : (
                   <CloseButton
@@ -130,7 +144,7 @@ export const DissertationList: React.FC<Props> = ({ slug, disableSearch }) => {
         </>
       )}
 
-      {error && (
+      {isError && (
         <Notification title="Error" color="red">
           {String(error)}
         </Notification>
@@ -144,8 +158,8 @@ export const DissertationList: React.FC<Props> = ({ slug, disableSearch }) => {
           <Progress value={100} animated striped />
         </Collapse>
 
-        {!loading &&
-          !error &&
+        {!loadingDebounced &&
+          !isError &&
           (dissertations?.length === 0 ? (
             <Text>No dissertations found. :(</Text>
           ) : (

--- a/frontend/src/interfaces.ts
+++ b/frontend/src/interfaces.ts
@@ -352,36 +352,6 @@ export type SearchResult =
   ExamSearchResult | AnswerSearchResult | CommentSearchResult;
 export type SearchResponse = SearchResult[];
 
-export interface Dissertation {
-  id: number;
-  title: string;
-  field_of_study: string;
-  supervisors: string;
-  notes: string;
-  file_path: string;
-  uploaded_by: string;
-  upload_date: string;
-  study_level: string;
-  grade_band?: string;
-  year: number;
-  relevant_categories: { slug: string; displayname: string }[];
-  can_edit: boolean;
-}
-
-export interface DissertationCreate {
-  words_to_redact: string;
-  title: string;
-  field_of_study: string;
-  supervisors: string;
-  notes: string;
-  study_level: string;
-  grade_band?: string;
-  year: number;
-  relevant_categories: string[];
-}
-
-export type DissertationUpdate = Partial<DissertationCreate>;
-
 export interface Stats {
   user_stats: UserStat[];
   exam_stats: ExamStat[];

--- a/frontend/src/pages/dissertation-detail-page.tsx
+++ b/frontend/src/pages/dissertation-detail-page.tsx
@@ -23,32 +23,44 @@ import {
   Flex,
 } from "@mantine/core";
 import { IconChevronRight, IconDownload, IconEdit } from "@tabler/icons-react";
-import { useRequest } from "ahooks";
-import { loadDissertation, loadDissertationPdf } from "../api/hooks";
 import useTitle from "../hooks/useTitle";
 import IconButton from "../components/icon-button";
 import DissertationUploadPage from "./dissertation-upload-page";
+import {
+  useDownloadDissertation,
+  useGetDissertationDetail,
+} from "../api/hooks/dissertations";
 
 const DissertationDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
   const {
-    loading: dissertationLoading,
     data: dissertation,
+    isLoading: dissertationLoading,
+    refetch: reloadDissertation,
+    isError: dissertationIsError,
     error: dissertationError,
-    run: reloadDissertation,
-  } = useRequest(() => loadDissertation(Number(id)), {
-    refreshDeps: [id],
+  } = useGetDissertationDetail(Number(id), {
+    query: {
+      select({ value: document }) {
+        return document;
+      },
+    },
   });
 
   const {
-    loading: pdfLoading,
     data: pdfUrl,
+    isLoading: pdfLoading,
+    refetch: reloadPdf,
+    isError: pdfIsError,
     error: pdfError,
-    run: reloadPdf,
-  } = useRequest(() => loadDissertationPdf(Number(id)), {
-    refreshDeps: [id],
+  } = useDownloadDissertation(Number(id), {
+    query: {
+      select({ value: document }) {
+        return document;
+      },
+    },
   });
 
   useTitle(dissertation ? dissertation.title : `Dissertation #${id}`);
@@ -65,7 +77,7 @@ const DissertationDetailPage: React.FC = () => {
     );
   }
 
-  if (dissertationError || pdfError) {
+  if (dissertationIsError || pdfIsError) {
     return (
       <Container size="xl" mt="xl">
         <Notification title="Error" color="red">

--- a/frontend/src/pages/dissertation-upload-page.tsx
+++ b/frontend/src/pages/dissertation-upload-page.tsx
@@ -24,19 +24,19 @@ import {
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useRequest } from "ahooks";
-import {
-  deleteDissertation,
-  editDissertation,
-  getRedactionPreview,
-  loadCategories,
-  uploadDissertation,
-} from "../api/hooks";
+import { loadCategories } from "../api/hooks";
 import serverData from "../utils/server-data";
-import { Dissertation } from "../interfaces";
 import useRemoveConfirm from "../hooks/useRemoveConfirm";
+import { DissertationSchema } from "../api/model";
+import {
+  useDeleteDissertation,
+  useRedactDissertation,
+  useUpdateDissertation,
+  useUploadDissertation,
+} from "../api/hooks/dissertations";
 
 interface Props {
-  editingExisting?: Dissertation;
+  editingExisting?: DissertationSchema;
   onEdit?: () => void;
 }
 
@@ -85,18 +85,17 @@ const DissertationUploadPage: React.FC<Props> = ({
   // Main form
   const form = useForm({
     initialValues: {
-      title: editing_existing ? editing_existing.title : "",
+      title: editing_existing?.title ?? "",
       field_of_study: editing_existing
         ? editing_existing.field_of_study
             .split(",")
             .filter(field => field.trim() !== "")
             .map(s => s.trim())
         : [],
-      supervisors: editing_existing ? editing_existing.supervisors : "",
-      notes: editing_existing ? editing_existing.notes : "",
-      study_level: editing_existing ? editing_existing.study_level : "",
-      grade_band:
-        editing_existing?.grade_band ?? (undefined as string | undefined),
+      supervisors: editing_existing?.supervisors ?? "",
+      notes: editing_existing?.notes ?? "",
+      study_level: editing_existing?.study_level ?? "",
+      grade_band: editing_existing?.grade_band ?? undefined,
       // Mantine Select only accepts strings as data - we need to convert back
       // when we submit
       year: editing_existing
@@ -111,7 +110,7 @@ const DissertationUploadPage: React.FC<Props> = ({
       title: (value: string) => (value ? null : "Title is required"),
       supervisors: (value: string) =>
         value ? null : "Supervisors are required",
-      study_level: (value: string) =>
+      study_level: (value: string | undefined) =>
         value ? null : "Study level is required",
       year: (value: string) =>
         value && /^[0-9]{4}$/.test(value)
@@ -120,65 +119,60 @@ const DissertationUploadPage: React.FC<Props> = ({
     },
   });
 
-  const { error: editError, run: runEditDissertation } = useRequest(
-    editDissertation,
-    {
-      manual: true,
-      onSuccess: data => {
-        onEdit?.();
-        void navigate(`/dissertations/${data.id}`);
-      },
-      onError: (e?: Error) => {
-        setClientValidationError(String(e));
-      },
-    },
-  );
-
-  const { error: uploadError, run: runUploadDissertation } = useRequest(
-    uploadDissertation,
-    {
-      manual: true,
-      onSuccess: data => {
-        void navigate(`/dissertations/${data.id}`);
-      },
-      onError: (e?: Error) => {
-        setClientValidationError(String(e));
-      },
-    },
-  );
-
   const {
-    error: previewError,
-    run: runGetRedactionPreview,
-    data: previewData,
-    loading: previewLoading,
-  } = useRequest(getRedactionPreview, {
-    manual: true,
-    onError: (e?: Error) => {
-      setClientValidationError(String(e));
+    mutate: runEditDissertation,
+    isError: editIsError,
+    error: editError,
+  } = useUpdateDissertation({
+    mutation: {
+      onSuccess: async ({ value: data }) => {
+        onEdit?.();
+        await navigate(`/dissertations/${data.id}`);
+      },
     },
   });
 
-  const [removeConfirm, modals] = useRemoveConfirm();
-  const { run: runDeleteDissertation } = useRequest(deleteDissertation, {
-    manual: true,
-    onSuccess: () => {
-      void navigate("/dissertations");
+  const {
+    mutate: runUploadDissertation,
+    isError: uploadIsError,
+    error: uploadError,
+  } = useUploadDissertation({
+    mutation: {
+      onSuccess: async ({ value: data }) => {
+        await navigate(`/dissertations/${data.id}`);
+      },
     },
-    onError: (e?: Error) => {
-      setClientValidationError(String(e));
+  });
+
+  const {
+    mutate: runGetRedactionPreview,
+    data: previewData,
+    isPending: previewLoading,
+    isError: previewIsError,
+    error: previewError,
+  } = useRedactDissertation();
+
+  const [removeConfirm, modals] = useRemoveConfirm();
+  const { mutate: runDeleteDissertation } = useDeleteDissertation({
+    mutation: {
+      onSuccess: async () => {
+        await navigate("/dissertations");
+      },
+      onError: (e?: Error) => {
+        setClientValidationError(String(e));
+      },
     },
   });
   const remove = useCallback(() => {
     if (editing_existing) {
       removeConfirm(
         "Are you sure you want to delete this dissertation? This action cannot be undone.",
-        () => void runDeleteDissertation(editing_existing.id),
+        () => runDeleteDissertation({ dissertationId: editing_existing.id }),
       );
     }
   }, [removeConfirm, runDeleteDissertation, editing_existing]);
 
-  const handleSubmit = async (values: typeof form.values) => {
+  const handleSubmit = (values: typeof form.values) => {
     setClientValidationError(null);
 
     if (!editing_existing) {
@@ -187,23 +181,10 @@ const DissertationUploadPage: React.FC<Props> = ({
         return;
       }
 
-      await runUploadDissertation(previewForm.values.pdf_file, {
-        // Pass the same words to redact as the preview
-        words_to_redact: previewForm.values.words_to_redact.join(","),
-        title: values.title,
-        field_of_study: values.field_of_study.join(","),
-        supervisors: values.supervisors,
-        notes: values.notes,
-        study_level: values.study_level,
-        grade_band: values.grade_band,
-        year: Number(values.year),
-        relevant_categories: values.relevant_categories,
-      });
-    } else {
-      await runEditDissertation(
-        previewForm.values.pdf_file,
-        editing_existing.id,
-        {
+      runUploadDissertation({
+        data: {
+          pdf_file: previewForm.values.pdf_file,
+          // Pass the same words to redact as the preview
           words_to_redact: previewForm.values.words_to_redact.join(","),
           title: values.title,
           field_of_study: values.field_of_study.join(","),
@@ -212,24 +193,42 @@ const DissertationUploadPage: React.FC<Props> = ({
           study_level: values.study_level,
           grade_band: values.grade_band,
           year: Number(values.year),
-          relevant_categories: values.relevant_categories,
+          relevant_categories: values.relevant_categories.join(","),
         },
-      );
+      });
+    } else {
+      runEditDissertation({
+        dissertationId: editing_existing.id,
+        data: {
+          pdf_file: previewForm.values.pdf_file,
+          words_to_redact: previewForm.values.words_to_redact.join(","),
+          title: values.title,
+          field_of_study: values.field_of_study.join(","),
+          supervisors: values.supervisors,
+          notes: values.notes,
+          study_level: values.study_level,
+          grade_band: values.grade_band,
+          year: Number(values.year),
+          relevant_categories: values.relevant_categories.join(","),
+        },
+      });
     }
   };
 
-  const handlePreviewSubmit = async (values: typeof previewForm.values) => {
+  const handlePreviewSubmit = (values: typeof previewForm.values) => {
     if (!values.pdf_file) {
       return;
     }
 
-    await runGetRedactionPreview(
-      values.pdf_file,
-      values.words_to_redact
-        .map(word => word.trim())
-        .filter(Boolean)
-        .join(","),
-    );
+    runGetRedactionPreview({
+      data: {
+        pdf_file: values.pdf_file,
+        words: values.words_to_redact
+          .map(word => word.trim())
+          .filter(Boolean)
+          .join(","),
+      },
+    });
   };
 
   return (
@@ -359,7 +358,7 @@ const DissertationUploadPage: React.FC<Props> = ({
                 required={!editing_existing} // Only require PDF for new uploads
                 onChange={e => {
                   previewForm.setFieldValue("pdf_file", e);
-                  void handlePreviewSubmit({
+                  handlePreviewSubmit({
                     ...previewForm.values,
                     // new form value isn't reflected until next render, so pass
                     // it directly here
@@ -388,7 +387,7 @@ const DissertationUploadPage: React.FC<Props> = ({
                 {...previewForm.getInputProps("words_to_redact")}
                 onChange={e => {
                   previewForm.setFieldValue("words_to_redact", e);
-                  void handlePreviewSubmit({
+                  handlePreviewSubmit({
                     ...previewForm.values,
                     // new form value isn't reflected until next render, so pass
                     // it directly here
@@ -511,13 +510,10 @@ const DissertationUploadPage: React.FC<Props> = ({
               {...form.getInputProps("notes")}
             />
 
-            {(clientValidationError ??
-              editError?.message ??
-              uploadError?.message) && (
+            {(clientValidationError ?? (editIsError || uploadIsError)) && (
               <Notification title="Upload Failed" color="red" mt="md">
                 {clientValidationError ??
-                  editError?.message ??
-                  uploadError?.message}
+                  (editIsError ? String(editError) : String(uploadError))}
               </Notification>
             )}
 
@@ -538,14 +534,14 @@ const DissertationUploadPage: React.FC<Props> = ({
           )}
         </div>
         <div style={{ flex: 1 }}>
-          {previewError && (
+          {previewIsError && (
             <Notification title="Preview Failed" color="red" mb="md">
               {String(previewError)}
             </Notification>
           )}
           {previewForm.values.pdf_file && previewData && (
             <iframe
-              src={previewData}
+              src={previewData.value}
               width="100%"
               height="100%"
               style={{ border: "none" }}

--- a/frontend/src/pages/dissertation-upload-page.tsx
+++ b/frontend/src/pages/dissertation-upload-page.tsx
@@ -95,6 +95,8 @@ const DissertationUploadPage: React.FC<Props> = ({
       supervisors: editing_existing?.supervisors ?? "",
       notes: editing_existing?.notes ?? "",
       study_level: editing_existing?.study_level ?? "",
+      // Mantine select uses undefined for no selection, but our API uses null
+      // - coerce one way here, and the other way when we submit
       grade_band: editing_existing?.grade_band ?? undefined,
       // Mantine Select only accepts strings as data - we need to convert back
       // when we submit
@@ -191,7 +193,7 @@ const DissertationUploadPage: React.FC<Props> = ({
           supervisors: values.supervisors,
           notes: values.notes,
           study_level: values.study_level,
-          grade_band: values.grade_band,
+          grade_band: values.grade_band ?? null,
           year: Number(values.year),
           relevant_categories: values.relevant_categories.join(","),
         },
@@ -207,7 +209,7 @@ const DissertationUploadPage: React.FC<Props> = ({
           supervisors: values.supervisors,
           notes: values.notes,
           study_level: values.study_level,
-          grade_band: values.grade_band,
+          grade_band: values.grade_band ?? null,
           year: Number(values.year),
           relevant_categories: values.relevant_categories.join(","),
         },
@@ -490,6 +492,7 @@ const DissertationUploadPage: React.FC<Props> = ({
               placeholder="Select grade band"
               mt="md"
               data={[
+                { value: "none", label: "--" },
                 { value: "40-49", label: "40-49" },
                 { value: "50-59", label: "50-59" },
                 { value: "60-69", label: "60-69" },
@@ -498,7 +501,7 @@ const DissertationUploadPage: React.FC<Props> = ({
                 { value: "90-100", label: "90-100" },
               ]}
               {...form.getInputProps("grade_band")}
-              clearable
+              defaultValue="none"
             />
 
             <Textarea


### PR DESCRIPTION
- Add some markup on the backend Dissertation API to improve its OpenAPI schema generation
- Migrate dissertation pages in frontend to use auto-generated React Query hooks derived from OpenAPI schema
- Fix not being able to unset the grade band of a dissertation once set
- Catch backend exceptions when PDF redaction fails due to malformed PDF